### PR TITLE
fixing https to http as not valid

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 <a id="community" class="anchor" href="#community" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Community</h3>
 
 <ul>
-<li><a href="https://www.ethereumclassic.org">https://www.ethereumclassic.org</a></li>
+<li><a href="http://www.ethereumclassic.org">http://www.ethereumclassic.org</a></li>
 <li><a href="https://www.reddit.com/r/EthereumClassic/">https://www.reddit.com/r/EthereumClassic/</a></li>
 </ul>
 


### PR DESCRIPTION
there is nothing listening on HTTPS for the **Community** links to `http://www.ethereumclassic.org`