### PR TITLE
fix: Remove non-working slideshare link for declaration and replace

### DIFF
--- a/images/download.svg
+++ b/images/download.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Download" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+<path d="M15,7h-3V1H8v6H5l5,5L15,7z M19.338,13.532c-0.21-0.224-1.611-1.723-2.011-2.114C17.062,11.159,16.683,11,16.285,11h-1.757
+	l3.064,2.994h-3.544c-0.102,0-0.194,0.052-0.24,0.133L12.992,16H7.008l-0.816-1.873c-0.046-0.081-0.139-0.133-0.24-0.133H2.408
+	L5.471,11H3.715c-0.397,0-0.776,0.159-1.042,0.418c-0.4,0.392-1.801,1.891-2.011,2.114c-0.489,0.521-0.758,0.936-0.63,1.449
+	l0.561,3.074c0.128,0.514,0.691,0.936,1.252,0.936h16.312c0.561,0,1.124-0.422,1.252-0.936l0.561-3.074
+	C20.096,14.468,19.828,14.053,19.338,13.532z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="Ethereum Classic : Keep the original censorship-resistant Ethereum going!">
-    <meta name="viewport" content="width=device-width,initial-scale=1,user-scaleable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1,user-scalable=no">
     <link rel="shortcut icon" type="image/png" href="https://i.imgur.com/WkgYTBT.png"/>
 
     <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
@@ -15,27 +15,27 @@
   <body>
 
     <!-- HEADER -->
+
     <div id="header_wrap" class="outer">
-        <div id="priceTicker"> 
-           <script type="text/javascript"> 
-             crypt_multi_num_cur = "2"; 
-             crypt_base_cur_0 = "Ethereum Classic (ETC)"; 
-             crypt_target_cur_0 = "Bitcoin (BTC)"; 
-             crypt_base_cur_1 = "Ethereum Classic (ETC)"; 
-             crypt_target_cur_1 = "US Dollar (USD)"; 
-             crypt_multi_background_color = "#000000"; 
-             crypt_multi_transperency = false; 
-             crypt_multi_border_color = "#008500"; 
-             crypt_multi_font_color = "#ffffff"; 
-           </script> 
-           <script src="https://www.cryptonator.com/ui/js/widget/multi_widget.js" type="text/javascript"> 
-           </script> 
-         </div>      
+        <div id="priceTicker">
+           <script type="text/javascript">
+             crypt_multi_num_cur = "2";
+             crypt_base_cur_0 = "Ethereum Classic (ETC)";
+             crypt_target_cur_0 = "Bitcoin (BTC)";
+             crypt_base_cur_1 = "Ethereum Classic (ETC)";
+             crypt_target_cur_1 = "US Dollar (USD)";
+             crypt_multi_background_color = "#000000";
+             crypt_multi_transperency = false;
+             crypt_multi_border_color = "#008500";
+             crypt_multi_font_color = "#ffffff";
+           </script>
+           <script src="https://www.cryptonator.com/ui/js/widget/multi_widget.js" type="text/javascript">
+           </script>
+         </div>
         <header class="inner">
 
           <h1 id="project_title">Ethereum Classic</h1>
           <h2 id="project_tagline">Keep the original censorship resistant Ethereum going!</h2>
-
         </header>
     </div>
 
@@ -47,23 +47,74 @@
 
         <h2>Ideology</h2>
 
-        <p>We believe in decentralized, censorship-resistant, permissionless blockchains. We believe in the original vision of Ethereum as a world computer you can't shut down, running irreversible smart contracts. We believe in a strong separation of concerns, where system forks are only possible in order to correct actual platform bugs or provide functionality upgrades, not to bail out failed contracts and special interests. We believe in censorship-resistant platform that can be actually trusted - by anyone.
-        <p>More: <a href="http://medium.com/@bit_novosti/a-crypto-decentralist-manifesto-6ba1fa0b9ede">http://medium.com/@bit_novosti/a-crypto-decentralist-manifesto-6ba1fa0b9ede</a></p>
-        </p>
+        <div class="declaration">
 
-        <h2>Motivation</h2>
+          <h3>The Ethereum Classic Declaration of Independence</h3>
 
-        <p>Ethereum Foundation responded to DAO debacle in the worst way possible. Special interests controlling the Foundation are ramming through DAO bailout hardfork against principled opposition of a significant economic minority of Ethereum stakeholders. According to (diligently hidden, pro-fork) coin vote on <a href="http://carbonvote.com/">Carbonvote</a>, 13% of ETH holders oppose this hardfork. Also, about 22% of Ethereum miners voted against the previous 'DAO softfork' and would logically oppose hardfork as well. Such a significant minority of stakeholders should not be silenced or intimidated into submission - they should be given a clear choice.</p>
+          <p>Let it be known to the entire world that on July 20th, 2016, at block 1,920,000, we as a community of sovereign individuals stood united by a common vision to continue the original Ethereum blockchain that is truly free from censorship, fraud or third party interference. In realizing that the blockchain represents absolute truth, we stand by it, supporting its immutability and its future. We do not make this declaration lightly, nor without forethought to the consequences of our actions.</p>
 
-        <p>If we want to continue to move forward and guarantee survival of the original Ethereum vision, we must fork Ethereum. This will lay the foundation to build secure decentralized applications that are actually censorship resistant.</p>
+          <h4>Looking Back</h4>
 
-        <p>More: <a href="http://github.com/ethereumclassic/freeworldcomputer-project">http://github.com/ethereumclassic/freeworldcomputer-project</a></p>
+          <p>It should be stated with great gratitude that we acknowledge the creation of the Ethereum blockchain platform by the Ethereum Foundation and its founding developers. It certainly can be said without objection, that without their hard work and dedication that we as a community would not be where we are today.</p>
 
-        <h2>Ethereum Classic Declaration of Independence</h2>
-        
-        <p>
-        <iframe width="668" height="714" src="//www.slideshare.net/slideshow/embed_code/key/5YnnWJrtS3Udwn" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" allowfullscreen="" style="border: 1px solid rgb(204, 204, 204); border-image: none; margin-bottom: 5px; max-width: 100%;"> </iframe>        
-        </p>
+          <p>From its inception, the Ethereum blockchain was presented as a decentralized platform for “applications that run exactly as programmed without any chance of fraud, censorship, or third-party interference”<a href="https://ethereum.org/" target="_blank"><sup>1</sup></a>. It provided a place for the free association of ideas and applications from across the globe without fear of discrimination while also providing pseudonymity. In this decentralized platform, many of us saw great promise.</p>
+
+          <h4>List of Grievances</h4>
+
+          <p>It is however, with deep regret, that we as a community have had to spontaneously organize<a href="https://www.reddit.com/r/EthereumClassic/comments/4u4o61/call_for_action_what_can_i_do_to_help_ethereum/" target="_blank"><sup>2</sup></a> to defend the Ethereum blockchain platform from its founding members and organization due to a long train of abuses, specifically by the leadership of the Ethereum Foundation. These grievances are as follows.</p>
+
+          <ul>
+            <li>For rushing the creation of a “soft fork,” which was comprised of a minor change in the Ethereum blockchain code for the sole purpose of creating a blacklist and censoring transactions that normally would have been allowed.</li>
+            <li>For neglecting the full implications of the “soft fork” by the Ethereum blockchain as a warning that they were violating the principles and values coded therein.<a href="https://blog.ethereum.org/2016/06/28/security-alert-dos-vulnerability-in-the-soft-fork/" target="_blank"><sup>3</sup></a></li>
+            <li>For creating an unrepresentative voting mechanism called the “carbon vote”, which they initially stated was “unofficial”<a href="https://www.reddit.com/r/ethereum/comments/4s0rz6/a_vote_that_nobody_knows_about_is_not_a_vote/d55nye3" target="_blank"><sup>4</sup></a> only to contradict these statements a day before determining to hard fork.<a href=" https://blog.ethereum.org/2016/07/15/to-fork-or-not-to-fork/" target="_blank"><sup>5</sup></a></li>
+            <li>For rushing the creation of a “hard fork,” which was comprised of an irregular state change in the Ethereum blockchain code that violated the properties of immutability, fungibility, and the sanctity of the ledger.</li>
+            <li>For willfully deciding to not include replay protection in the “hard fork”, an action which has unnecessarily cost exchanges and thousands of users the rightful ownership of their Ether tokens.<a href="https://pbs.twimg.com/media/CopwJVHXEAABEKd.jpg" target="_blank"><sup>6</sup></a></li>
+          </ul>
+
+          <h4>Respecting the Values Essential for Blockchains</h4>
+
+          <p>One might ask what harm can be done from changing the code of the Ethereum blockchain and bailing out<a href="https://dictionary.cambridge.org/us/dictionary/english/bailout" target="_blank"><sup>7</sup></a> “The DAO” token holders, which is not an unreasonable question. Many of us have an innate sense of right and wrong, so at first glance rescuing "The DAO" felt right. However, it violated two key aspects of what gives peer-to-peer cash<a href="https://bitcoin.org/bitcoin.pdf" target="_blank"><sup>8</sup></a> and smart contract-based systems value: fungibility and immutability.</p>
+
+          <p>Immutability means the blockchain is inviolable. That only valid transactions agreed upon via a cryptographic protocol determined by mathematics are accepted by the network. Without this, the validity of all transactions could come into question, since if the blockchain is mutable, any transaction could be modified. Not only does this leave transactions open to fraud, but it might spell disaster for any distributed application running atop the platform.</p>
+
+          <p>Fungibility is the feature of money where one unit equals another unit. For instance, a Euro equals another Euro just as a Bitcoin equals another Bitcoin. Unfortunately, an ETH no longer equals another ETH. The alleged attacker’s ETH was no longer as good as your ETH and was worthy of censorship, deemed necessary by a so-called majority.</p>
+
+          <p>Ultimately, these breaches in fungibility and immutability were made possible by the subjective morality judgements of those who felt a burning desire to bring the alleged attacker to justice. However, in doing so they compromised a core pillar of Ethereum just to do what they felt was in the interests of the “greater good”. In a global community where each individual has their own laws, customs, and beliefs, who is to say what is right and wrong?</p>
+
+          <p>Deeply alarmed that these core tenets were disregarded by many of the Foundation’s developers, and a sizable portion of Ethereum participants, we, as a community, have organized and formed a code of principles to follow for the Ethereum Classic chain.</p>
+
+          <h4>The Ethereum Classic Code of Principles</h4>
+
+          <p>We believe in a decentralized, censorship-resistant, permission-less blockchain. We believe in the original vision of Ethereum as a world computer that cannot be shut down, running irreversible smart contracts. We believe in a strong separation of concerns, where system forks of the codebase are only possible when fixing protocol level vulnerabilities, bugs, or providing functionality upgrades. We believe in the original intent of building and maintaining a censorship-resistant, trustless and immutable development platform.</p>
+
+          <p>Herein are written the declared values by which participants within the Ethereum Classic community agree. We encourage that these principles not be changed via edict by any individual or faction claiming to wield power, authority or credibility to do so.</p>
+
+          <p>We, as a community agree that:</p>
+
+          <ul>
+            <li>The purpose of Ethereum Classic is to provide a decentralized platform that runs decentralized applications which execute exactly as programmed without any possibility of downtime, censorship, fraud or third party interference.</li>
+            <li>Code is law; there shall be no changes to the Ethereum Classic code that violate the properties of immutability, fungibility, or sanctity of the ledger; transactions or ledger history cannot for any reason be reversed or modified.</li>
+            <li>Forks and/or changes to the underlying protocol shall only be permitted for updating or upgrading the technology on which Ethereum Classic operates.</li>
+            <li>Internal project development can be funded by anyone, whether via a trusted third party of their choice or directly, using the currency of their choice on a per project basis and following a transparent, open and decentralized crowdfunding protocol.</li>
+            <li>Any individual or group of individuals may propose improvements, enhancements, or upgrades to existing or proposed Ethereum Classic assets.</li>
+            <li>Any individual or group of individuals may use the Ethereum Classic decentralized platform to build decentralized applications, hold crowdsales, create autonomous organisations/corporations, or for any other purpose they deem suitable.</li>
+          </ul>
+
+          <h4>Looking Forward</h4>
+
+          <p>For the many reasons listed above, we have chosen to rename the original blockchain “Ethereum Classic” with the ticker symbol “ETC”, so that the community and all other participants can identify the original, unforked, and immutable blockchain platform.</p>
+
+          <p>Our most sincere gratitude goes to those developers within and outside the Foundation who opposed interfering with the Ethereum blockchain ledger and enabled the Ethereum Classic chain to survive and live on. We know there are many of you and we welcome you at anytime to join our decentralized community.</p>
+
+          <p>We will continue the vision of decentralized governance for the Ethereum Classic blockchain and maintain our opposition to any centralized leadership takeover, especially by the Ethereum Foundation as well as the developers who have repeatedly stated that they would no longer develop the Ethereum Classic chain.</p>
+
+          <p>We likewise will openly resist the “tyranny of the majority,” and will not allow the values of the system to be compromised. As a united community, we will continue to organize for the defense and advancement, as required, for the continuation and assurance of this grand experiment. The Ethereum Classic platform, its code and technology, are now open to the world as Open Source software.<a href="https://github.com/ethereumproject" target="_blank"><sup>9</sup></a> It is now freely available for all who wish to improve and build upon it: a truly free and trustless world computer that we together as a community have proven and will continue to prove is anti-fragile.<a href="https://www.goodreads.com/book/show/13530973-antifragile" target="_blank"><sup>10</sup></a></p>
+
+          <p>- <i>The Ethereum Classic Community</i></p>
+
+          <a href="https://ethereumclassic.github.io/assets/ETC_Declaration_of_Independence.pdf" download><img class="download-declaration" src="images/download.svg" alt="declaration download button"></a>
+
+        </div>
 
         <h2>Goals</h2>
 
@@ -75,7 +126,7 @@
 
         <p>We fork Ethereum and maintain upstream patches similar to the relation between Redhat and CentOS, until a community can form around the project and create a road map. Until this happens we can fork multiple existing clients to help prevent a monoculture of clients. We plan to follow <a href="http://github.com/ethereum">http://github.com/ethereum</a> development except for any features they introduce into existing clients that violate the key principles of openness, neutrality and immutability.</p>
 
-        <p>Code: <a href="http://github.com/ethereumclassic">http://github.com/ethereumclassic</a>, <a href="http://github.com/ethereumproject">http://github.com/ethereumproject</a></p>
+        <p>Code: <a href="http://github.com/ethereumclassic">http://github.com/ethereumclassic</a>, <a href="http://github.com/ethereumproject">http://github.com/ethereumproject</a>, <a href="http://github.com/ethereumclassic/freeworldcomputer-project">http://github.com/ethereumclassic/freeworldcomputer-project</a></p>
 
         <ul>
           <li>Telegram: <a href="https://telegram.me/etcdev">@etcdev</a></li>
@@ -123,7 +174,6 @@
 
         <ul>
           <li><a href="http://ethc.epool.io">ethc.epool.io</a>  (<a href="https://www.reddit.com/r/EthereumClassic/comments/4tcdmc/ethc_classic_mining_pool/">support thread</a>)</li>
-          <li><a href="http://ethc.epool.io">ethc.epool.io</a>  (<a href="https://www.reddit.com/r/EthereumClassic/comments/4tcdmc/ethc_classic_mining_pool/">support thread</a>)</li>
           <li><a href="http://pool.ethereumclassic.com">pool.ethereumclassic.com</a></li>
           <li><a href="http://etc.nanopool.org">etc.nanopool.org</a></li>
           <li><a href="https://etcpool.io">etcpool.io</a></li>
@@ -133,8 +183,8 @@
           <li><a href="http://etc.altpool.net/">etc.altpool.net</a></li>
           <li><a href="http://ethteam.com/">ethteam.com</a></li>
           <li><a href="http://etc-pool.com">etc-pool.com</a></li>
-          <li><a href="https://ethereum-classic.miningpoolhub.com/">https://ethereum-classic.miningpoolhub.com/</a></li>
-          
+          <li><a href="https://ethereum-classic.miningpoolhub.com">ethereum-classic.miningpoolhub.com</a></li>
+
         </ul>
 
         <p>Additional info on <a href="https://www.reddit.com/r/EthereumClassic/comments/4ti33y/classic_miners_please_use_geth_149_for_now/">solo mining and more mining tips</a>. </p>
@@ -187,7 +237,7 @@
     <div class="outer" id="footer_wrap">
       <footer class="inner">
         <script src="//platform.linkedin.com/in.js" type="text/javascript"> lang: en_US</script>
-        <script type="IN/FollowCompany" data-id="10883680" data-counter="right"></script>   &nbsp;&nbsp;   
+        <script type="IN/FollowCompany" data-id="10883680" data-counter="right"></script>   &nbsp;&nbsp;
         <a href="https://twitter.com/ethereumclassic" class="twitter-follow-button" data-show-count="false">Follow @ethereumclassic</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
       </footer>
     </div>

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -14,7 +14,7 @@ h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
 del, dfn, em, img, ins, kbd, q, s, samp,
 small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
+b, u, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
@@ -27,6 +27,20 @@ time, mark, audio, video {
   border: 0;
   font: inherit;
   vertical-align: baseline;
+}
+
+sub,
+sup {
+font-size: 75%;
+line-height: 0;
+position: relative;
+vertical-align: baseline;
+}
+sup {
+top: -0.5em;
+}
+sub {
+bottom: -0.25em;
 }
 
 /* HTML5 display-role reset for older browsers */
@@ -358,6 +372,18 @@ Full-Width Styles
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 
+}
+
+.declaration {
+  background-color: #fff;
+  padding: 20px;
+}
+
+.download-declaration {
+  float: right;
+  width: 25px;
+  height: 25px;
+  margin-top: -20px;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
The slideshare embedded link to the declaration isn't working properly, so I just inlined the declaration to the top of the page and removed redundant text.