### PR TITLE
Allow system font while custom font is still loading

### DIFF
--- a/src/assets/sass/phoenix/base/typography.scss
+++ b/src/assets/sass/phoenix/base/typography.scss
@@ -25,7 +25,6 @@ h1 {
   small {
     font-family: '_HeaderFont';
     font-weight: normal;
-    font-display: swap;
   }
 }
 

--- a/src/assets/sass/phoenix/base/typography.scss
+++ b/src/assets/sass/phoenix/base/typography.scss
@@ -2,19 +2,22 @@
   font-family: '_HeaderFont';
   src: url("../webfonts/Oswald-VariableFont_wght.ttf");
   font-weight: 1 999;
+  font-display: swap;
 }
 
 @font-face {
   // weight < 500 
   font-family: '_BodyFont';
   src: url("../webfonts/Yantramanav-Light.ttf");
+  font-display: swap;
 }
 
 @font-face {
   // weight > 500
   font-family: '_BodyFont';
   src: url("../webfonts/Yantramanav-Bold.ttf");
-  font-weight: bold; 
+  font-weight: bold;
+  font-display: swap;
 }
 
 h1 {
@@ -22,6 +25,7 @@ h1 {
   small {
     font-family: '_HeaderFont';
     font-weight: normal;
+    font-display: swap;
   }
 }
 


### PR DESCRIPTION
Based on [Google page speed test](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fethereumclassic.org%2F), we can save potentially 180ms of page load time by allowing system font while the fonts are loading. 

<img width="828" alt="Screen Shot 2020-04-29 at 1 20 14 PM" src="https://user-images.githubusercontent.com/2533512/80643051-4fc13180-8a1c-11ea-98b1-31ed4b70409c.png">

This means users can see the page faster on slower connections, and we can get better SEO.

Fix information: https://web.dev/font-display/?utm_source=lighthouse&utm_medium=unknown