### PR TITLE
Added in Alpha Wallet / Replace Trust Wallet in Porting Page

### DIFF
--- a/content/development/porting/index.en.yaml
+++ b/content/development/porting/index.en.yaml
@@ -16,7 +16,7 @@ content:
         key: Commonwealth.gg
         name: Commonwealth.gg
         link: https://commonwealth.gg/
-        description: An open source Hourglass contract similar to original P3D built on Ethereum Classic. Can be leveraged with applications that incentivize user participation via dividends.
+        description: An open source Hourglass contract evolved from P3D/FOMO3D built on Ethereum Classic. Can be leveraged with applications that incentivize user participation via ETC dividends.
       - 
         key: DappDirect.net
         name: DappDirect.net
@@ -68,7 +68,7 @@ content:
         link: https://github.com/second-state/soll
         description: The LLVM compiler is finally coming to Solidity. With it, we can easily create smart contracts across multiple blockchain VMs. The EVM on Ethereum Classic and ETH 2.0's eWASM are among the first we support.
       - 
-        key: Trust Wallet
-        name: Trust Wallet (Mobile dApp Browser)
-        link: https://trustwallet.com/
-        description: An open source, multi-currency, Web3 mobile wallet. Has been tested and confirmed to work properly with ETC dApps.
+        key: Alpha Wallet
+        name: Alpha Wallet (Mobile dApp Browser)
+        link: https://alphawallet.com/
+        description: An open source, multi-currency, Web3 mobile wallet. Has been tested and confirmed to work properly with ETC dApps on Android and iOS

--- a/content/ecosystem/wallets/index.en.yaml
+++ b/content/ecosystem/wallets/index.en.yaml
@@ -201,10 +201,6 @@ content:
         link: https://tokenview.com/cn/download
         name: Tokenview
       -
-        key: Alpha Wallet
-        link: https://alphawallet.com/
-        name: Alpha Wallet
-      -
         key: Trust Wallet
         link: https://trustwallet.com/
         name: Trust Wallet

--- a/content/ecosystem/wallets/index.en.yaml
+++ b/content/ecosystem/wallets/index.en.yaml
@@ -201,6 +201,10 @@ content:
         link: https://tokenview.com/cn/download
         name: Tokenview
       -
+        key: Alpha Wallet
+        link: https://alphawallet.com/
+        name: Alpha Wallet
+      -
         key: Trust Wallet
         link: https://trustwallet.com/
         name: Trust Wallet


### PR DESCRIPTION
Trust Wallet has recently deprecated their Web3 Dapp Browser. Announcement here: https://community.trustwallet.com/t/trust-wallet-removed-dapp-browser-to-comply-with-apple-app-store-guidelines/30593

Alpha Wallet recently upgraded their ETC Dapp Browser support.