### PR TITLE
Inactive

### DIFF
--- a/content/ecosystem/social-channels/index.en.yaml
+++ b/content/ecosystem/social-channels/index.en.yaml
@@ -37,7 +37,7 @@ content:
     -
       key: chat Slack
       link: https://ethereumclassic.herokuapp.com/
-      name: Slack
+      name: Slack (English)
       brand: slack
     -
       key: chat WeChat
@@ -61,7 +61,7 @@ content:
       brand: gitter
     -
       key: Core Paper dev
-      link: https://discord.io/ethereumclassic
+      link: https://discord.com/invite/BdRSvJD
       name: Core Paper
       brand: discord
     -

--- a/content/ecosystem/social-channels/index.en.yaml
+++ b/content/ecosystem/social-channels/index.en.yaml
@@ -60,7 +60,7 @@ content:
       name: Core-Geth
       brand: gitter
     -
-      key: Core Paper dev
+      key: Core Paper dev 
       link: https://discord.com/invite/BdRSvJD
       name: Core Paper
       brand: discord

--- a/content/ecosystem/teams/index.en.yaml
+++ b/content/ecosystem/teams/index.en.yaml
@@ -119,7 +119,7 @@ content:
       - key: Core Paper
         year: 2019
         name: Core Paper
-        active: true
+        className: faded
         link: https://corepaper.org/
         twitter: https://twitter.com/corepaper
         github: https://github.com/corepaper

--- a/content/ecosystem/teams/index.en.yaml
+++ b/content/ecosystem/teams/index.en.yaml
@@ -137,3 +137,10 @@ content:
         link: https://www.godel.ai/
         twitter: https://twitter.com/Goedellabs
         github: https://github.com/multi-geth/multi-geth
+      - key: OpenETC
+        year: 2020
+        name: OpenETC
+        active: true
+        link: https://openetc.org/
+        twitter: https://twitter.com/cryptoasuka
+        github: https://github.com/openetc/openetc


### PR DESCRIPTION
- Update CorePaper to inactive status as desired by the developer.
- Change social discord link to remove ETC vanity redirect to prevent confusion that this team is still associated with ETC per developer wishes.

Reference: https://github.com/ethereumclassic/ECIPs/issues/325#issuecomment-664813509

+ Add OpenETC active team.
+ Add English label to the Slack Chat button.

