### PR TITLE
Change notice of update clients on page

### DIFF
--- a/content/ui.global.en.yaml
+++ b/content/ui.global.en.yaml
@@ -30,8 +30,9 @@ continueReading: Continue Reading
 ## pop up
 warning:
   enabled: true
-  title: "Urgent: Update ETC Clients"
-  description: "Please update your ETC clients to the newest release, critical bugs have been indentified and patched. The client software will be compatible with the Thanos upgrade (ECIP 1099) scheduled for block 11_700_000 in December 2020."
+  type: notice
+  title: "Update ETC Clients"
+  description: "Make sure your ETC clients are in the newest release. The new clients are compatible with the latest Thanos upgrade (ECIP 1099) performed on block 11_700_000 in December 2020."
   button:
     link: /development/clients
     text: Update Clients

--- a/src/assets/sass/phoenix/_main.scss
+++ b/src/assets/sass/phoenix/_main.scss
@@ -14,3 +14,4 @@
 @import './typography.scss';
 @import './video.scss';
 @import './warning.scss';
+@import './notice.scss';

--- a/src/assets/sass/phoenix/notice.scss
+++ b/src/assets/sass/phoenix/notice.scss
@@ -1,0 +1,56 @@
+.notice-container {
+  position: fixed;
+  width: 100%;
+  z-index: 3;
+  transition: opacity .5s ease-in-out;
+  pointer-events: none;
+
+  &.hidden {
+    opacity: 0;
+    user-select: none;
+
+    .notice-overlay {
+      pointer-events: none;
+    }
+  }
+
+  .notice-overlay {
+    pointer-events: auto;
+    position: relative;
+
+    @include themify() {
+      background: transparentize(_themed(fg), 0.05);
+    }
+
+    box-shadow: $hardShadow;
+    text-shadow: $textShadow;
+    width: 40rem;
+    max-width: 80%;
+    margin: auto;
+    margin-top: 1rem;
+    border-radius: $roundedTight;
+    padding: 1rem 1.4rem;
+
+    .close-button {
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 2rem;
+      height: 2rem;
+      cursor: pointer;
+      text-align: center;
+    }
+
+    h3,
+    p {
+      line-height: 1.4rem;
+      margin: 0.5rem 0;
+    }
+
+    .action {
+      float: right;
+      padding-left: 1rem;
+    }
+  }
+
+}

--- a/src/components/Warning.js
+++ b/src/components/Warning.js
@@ -14,8 +14,8 @@ const Warning = ({ i18n }) => {
     setTimeout(() => setShowing(true), 1000 * 2);
   }, []);
   return (
-    <div className={`warning-container ${!showing ? 'hidden' : ''}`}>
-      <div className="warning-overlay dark">
+    <div className={`${!i18n.type ? 'warning' : i18n.type}-container ${!showing ? 'hidden' : ''}`}>
+      <div className={`${!i18n.type ? 'warning' : i18n.type}-overlay dark`}>
         <div className="close-button" onClick={() => setShowing(false)} role="button">
           <i className="fa fa-times" />
         </div>


### PR DESCRIPTION
Notice on ethereumclassic is old and is refering to a future upcoming event.

Since Ecip-1099 has already been performed, I sugest change the red color of warning to a notice for more one month before take it off, red color and some words like "critical bugs" to non technical people is a bad image passed.





