### PR TITLE
No frontpage apps

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/javascript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/javascript-node
+{
+	"name": "Node.js",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+		// Append -bullseye or -buster to pin to an OS version.
+		// Use the -bullseye variants if you are on a M1 mac.
+		"args": { "VARIANT": "12" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/content/ecosystem/apps-and-protocols/apps.en.yaml
+++ b/content/ecosystem/apps-and-protocols/apps.en.yaml
@@ -9,6 +9,12 @@ legends:
   other: Other
 items: 
 - 
+  key: ETCBits
+  name: ETCBits
+  link: https://medium.com/@persn.assist/etcbits-1st-3d-collection-and-only-2nd-nft-collection-on-ethereum-classic-547e787f5633
+  text: ETCbits — 1st 3D collection and only 2nd NFT collection on Ethereum Classic
+  type: nft
+- 
   key: ETCPunks
   name: ETCPunks
   link: https://etcpunks.com/

--- a/content/news/index.en.yaml
+++ b/content/news/index.en.yaml
@@ -3,6 +3,7 @@ description: Blog articles and news links from all over the internet pertaining 
 submit: Submit Links or Articles
 englishItems: English News
 intro: Ethereum Classic Blog and Links from all over the internet
+disclaimer: true
 rss: 
   text: News RSS Feed
   link: /rss.xml

--- a/content/news/media/index.en.yaml
+++ b/content/news/media/index.en.yaml
@@ -3,6 +3,7 @@ description: List of Ethereum Classic related media; news links to external site
 submit: Submit Link
 englishItems: English Links
 intro: Technical Ethereum Classic news and media from all over the internet.
+disclaimer: true
 rss: 
   text: Links RSS Feed
   link: /rss-links.xml

--- a/content/news/media/media.collection.en.yaml
+++ b/content/news/media/media.collection.en.yaml
@@ -1,3 +1,11 @@
+
+-  
+  date: 2021-11-24
+  link: https://medium.com/@persn.assist/etcbits-1st-3d-collection-and-only-2nd-nft-collection-on-ethereum-classic-547e787f5633
+  author: ETCBits
+  source: Medium
+  title: "ETCbits — 1st 3D collection and only 2nd NFT collection on Ethereum Classic"
+  tags: ["announcement", "development", "application"]
 -  
   date: 2021-09-23
   link: https://etccooperative.org/posts/2019-09-23-july-august-board-package/
@@ -11,7 +19,7 @@
   author: Kara Bhai
   source: Medium
   title: "ETCPunks: The First NFTs on Ethereum Classic"
-  tags: ["announcement", "development", "applications"]
+  tags: ["announcement", "development", "application"]
 -  
   date: 2021-09-20
   link: https://etccooperative.org/posts/2021-09-20-withdraws-support-for-ecip-1098/

--- a/src/assets/sass/phoenix/color-grid.scss
+++ b/src/assets/sass/phoenix/color-grid.scss
@@ -116,5 +116,13 @@
       background: _themed(orange-col);
       color: _themed(dark-orange-col);
     }
+
+    .color-grid-legend .key.grid-color-6,
+    .color-grid-items .card.grid-color-6:hover,
+    .color-grid-items .card.grid-color-6 h4 {
+      background: _themed(bg);
+      color: _themed(fg);
+    }
+
   }
 }

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -41,6 +41,7 @@ export const query = graphql`
         locale: { eq: $locale }
         type: { in: ["collection", "markdown"] }
         parentDirectory: { in: ["blog", "news"] }
+        data: { tags: { nin: "application" } }
       }
       sort: { fields: data___date, order: DESC }
       limit: 10


### PR DESCRIPTION
In resposne to #690 , this PR removes news items with the tag `application` from the front page, but they remain in the news page and I have added the ETCBits app to the ecoystem page.

This is a tempory solution until the new website is released.

I have also added docker config for easier development.