### PR TITLE
Add ETC HODL Contract

### DIFF
--- a/content/ecosystem/apps-and-protocols/apps.en.yaml
+++ b/content/ecosystem/apps-and-protocols/apps.en.yaml
@@ -45,6 +45,12 @@ items:
   text: ETCPunks are inspired collectibles, the first NFT porject on Ethereum Classic! Only 10,000 made, all with unique features. Collect them, buy one as a gift for someone or trade them on the marketplace!
   type: nft
 - 
+  key: ETC HODL Contract
+  name: ETC HODL Contract
+  link: https://ipfs.io/ipfs/QmVWD1sHPrKMmKcWoSPHGTfDpgaa8N4y6arftpFCnpJWcg
+  text: A simple HODL protocol for Ethereum Classic. Lock up your ETC and earn rewards when others unlock their ETC before you do.
+  type: Finance
+- 
   key: Aqua Bank
   name: Aqua Bank
   type: game

--- a/content/ecosystem/apps-and-protocols/apps.en.yaml
+++ b/content/ecosystem/apps-and-protocols/apps.en.yaml
@@ -49,7 +49,7 @@ items:
   name: ETC HODL Contract
   link: https://ipfs.io/ipfs/QmVWD1sHPrKMmKcWoSPHGTfDpgaa8N4y6arftpFCnpJWcg
   text: A simple HODL protocol for Ethereum Classic. Lock up your ETC and earn rewards when others unlock their ETC before you do.
-  type: Finance
+  type: finance
 - 
   key: Aqua Bank
   name: Aqua Bank


### PR DESCRIPTION
Contract address: `0x3B20DF51FAbc46e8A8BE13C295569D88D12f6868`

Code verified on BlockScout.

Website hosted on IPFS in the interest of decentralization.

Carefully tested on Rinkeby and ETC mainnet.  See discussion on Discord (general thread, 1/6/22) to understand the purpose and the mechanics of this contract.

[Rinkeby Integration Test](https://github.com/ethereumclassic/ethereumclassic.github.io/files/7825447/hodl.integration.test.txt)