### PR TITLE
Add SimpleHold wallet to browser extension wallets

### DIFF
--- a/content/ecosystem/wallets/index.en.yaml
+++ b/content/ecosystem/wallets/index.en.yaml
@@ -52,6 +52,10 @@ content:
         key: Saturn Wallet
         link: https://www.saturn.network/blog/saturn-wallet-user-manual/
         name: Saturn Wallet
+      -
+        key: SimpleHold Wallet
+        link: https://simplehold.io/download
+        name: SimpleHold Wallet
   -
     key: hardware
     type: buttons


### PR DESCRIPTION
Add SimpleHold wallet to the website as it supports Ethereum Classic. You can find it in the list of assets here: https://simplehold.io/coins