### PR TITLE
Add Coin Wallet

### DIFF
--- a/content/services/wallets/index.en.yaml
+++ b/content/services/wallets/index.en.yaml
@@ -114,6 +114,9 @@ items:
       Cobo:
         __link: https://cobo.com/
         name: Cobo
+      Coin Wallet:
+        __link: https://coin.space/
+        name: Coin Wallet
       Coinbase Wallet:
         __link: https://wallet.coinbase.com/
         name: Coinbase Wallet


### PR DESCRIPTION
Hi,

This PR adds Coin Wallet to the list of software wallets.
Ethereum Classic was added in [v5.3.0](https://github.com/CoinSpace/CoinSpace/releases/tag/v5.3.0).