### PR TITLE
The JPEG for nanli777's WeChat QR code has been replicated on ETC Cooperative's server.

### DIFF
--- a/content/community/channels/index.en.yaml
+++ b/content/community/channels/index.en.yaml
@@ -46,7 +46,7 @@ items:
         __icon: slack
         name: Slack (English)
       chat WeChat:
-        __link: hhttps://etccooperative.org/nanli777.jpg
+        __link: https://etccooperative.org/nanli777.jpg
         name: WeChat (中文)
   Development Chat:
     __type: buttons

--- a/content/community/channels/index.en.yaml
+++ b/content/community/channels/index.en.yaml
@@ -46,7 +46,7 @@ items:
         __icon: slack
         name: Slack (English)
       chat WeChat:
-        __link: https://hebeswap.com/assets/nanli777.jpg
+        __link: hhttps://etccooperative.org/nanli777.jpg
         name: WeChat (中文)
   Development Chat:
     __type: buttons


### PR DESCRIPTION
The JPEG for nanli777's WeChat QR code has been replicated on ETC Cooperative's server.

This is intended to make clear that 777 does not work for Hebe. 777 is the organizer for the primary Chinese-language WeChat and Telegram channels.

For the WeChat channel, it is not possible for users to auto-add themselves. They need to connect with 777 and have him add them to the channel. This is due to intrinsic constraints in the WeChat platform.

Zhang on the ETC Cooperative Discord on 12th October 2022: https://discord.com/channels/1008576041440252015/1008576041939369998/1029830977788321894

"Usually, they will reply in private chat: etc, and he will pull the user into the etc WeChat channel. If there are less than 200 people, you can directly let users join through the QR code. If there are more than 200 people, you can only invite users manually. And each WeChat group, the upper limit is 500 people, etc. WeChat group now has 400 people, will soon reach the upper limit, open 2 groups"