### PR TITLE
Remove Coinbase Wallet

### DIFF
--- a/content/services/wallets/index.yaml
+++ b/content/services/wallets/index.yaml
@@ -144,10 +144,6 @@ items:
       Coin Wallet:
         __link: https://coin.space/
         __name: Coin Wallet
-      Coinbase Wallet:
-        __link: https://wallet.coinbase.com/
-        __primary: 1
-        __name: Coinbase Wallet
       Coinomi:
         __link: https://www.coinomi.com/
         __name: Coinomi
@@ -160,6 +156,7 @@ items:
       Emerald Wallet:
         __link: https://emerald.cash/
         __name: Emerald Wallet
+        __primary: 1
       Ethos:
         __link: https://www.ethos.io/universal-wallet/
         __name: Ethos
@@ -170,8 +167,9 @@ items:
         __link: https://evercoin.com
         __name: Evercoin
       Exodus:
-        __link: https://www.exodus.io/
+        __link: https://www.exodus.com/
         __name: Exodus
+        __primary: 1
       Guarda:
         __link: https://guarda.com/
         __name: Guarda


### PR DESCRIPTION
- Remove Coinbase Wallet (delisted ETC from wallet a few months back)
+ Highlight Emerald Wallet (Former ETC Dev Lead. Long Time ETC Wallet)
+ Highlight Exodus Wallet (One of the longest running self-custody Multicoin Software Wallets. Nice UI//UX)