### PR TITLE
Fix tags of remaining articles.

### DIFF
--- a/content/blog/2023-03-02-ethereum-classic-course-11-ethereum-classic-social-and-physical-layer-security/index.md
+++ b/content/blog/2023-03-02-ethereum-classic-course-11-ethereum-classic-social-and-physical-layer-security/index.md
@@ -3,7 +3,7 @@ title: "Ethereum Classic Course: 11. Ethereum Classic Social and Physical Layer 
 date: 2023-03-02
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-tags: ["Course", "Education"]
+tags: ["series", "education"]
 linkImage: ./etc-social-physical-banner.png
 ---
 

--- a/content/blog/2023-03-02-ethereum-classic-course-11-ethereum-classic-social-and-physical-layer-security/index.zh.md
+++ b/content/blog/2023-03-02-ethereum-classic-course-11-ethereum-classic-social-and-physical-layer-security/index.zh.md
@@ -3,7 +3,7 @@ title: "以太坊经典课程: 11.以太坊经典社会和物理层安全"
 date: 2023-03-02
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-tags: ["Course", "Education"]
+tags: ["series", "education"]
 linkImage: ./etc-social-physical-banner.png
 ---
 

--- a/content/blog/2023-03-07-ethereum-classic-centralized-and-decentralized-exchanges/index.md
+++ b/content/blog/2023-03-07-ethereum-classic-centralized-and-decentralized-exchanges/index.md
@@ -3,7 +3,7 @@ title: "Ethereum Classic, Centralized, and Decentralized Exchanges"
 date: 2023-03-07
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-tags: ["Tutorials", "Education"]
+tags: ["education"]
 linkImage: ./2.png
 ---
 

--- a/content/blog/2023-03-07-ethereum-classic-centralized-and-decentralized-exchanges/index.zh.md
+++ b/content/blog/2023-03-07-ethereum-classic-centralized-and-decentralized-exchanges/index.zh.md
@@ -3,7 +3,7 @@ title: "以太坊经典, 中心化、和去中心化的交易所"
 date: 2023-03-07
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-tags: ["Tutorials", "Education"]
+tags: ["Education"]
 linkImage: ./2.png
 ---
 

--- a/content/blog/2023-03-07-ethereum-classic-centralized-and-decentralized-exchanges/index.zh.md
+++ b/content/blog/2023-03-07-ethereum-classic-centralized-and-decentralized-exchanges/index.zh.md
@@ -3,7 +3,7 @@ title: "以太坊经典, 中心化、和去中心化的交易所"
 date: 2023-03-07
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-tags: ["Education"]
+tags: ["education"]
 linkImage: ./2.png
 ---
 

--- a/content/blog/2023-03-09-ethereum-classic-course-12-proof-of-stake-explained/index.md
+++ b/content/blog/2023-03-09-ethereum-classic-course-12-proof-of-stake-explained/index.md
@@ -3,7 +3,7 @@ title: "Ethereum Classic Course: 12. Proof of Stake Explained"
 date: 2023-03-09
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-tags: ["course", "education"]
+tags: ["series", "education"]
 linkImage: ./banner.png
 ---
 

--- a/content/blog/2023-03-09-ethereum-classic-course-12-proof-of-stake-explained/index.zh.md
+++ b/content/blog/2023-03-09-ethereum-classic-course-12-proof-of-stake-explained/index.zh.md
@@ -3,7 +3,7 @@ title: "以太坊经典课程12. 权益证明详解"
 date: 2023-03-09
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-tags: ["course", "education"]
+tags: ["series", "education"]
 linkImage: ./banner.png
 ---
 


### PR DESCRIPTION
Fix tags to eliminate "Course", "course", and "Tutorial" and replace them with "education" and "series" in some articles that were in the pipeline but were not corrected.