### PR TITLE
Fix Philosophy tag in one article.

### DIFF
--- a/content/blog/2023-03-08-ethereum-classics-focus-on-trust-minimization/index.md
+++ b/content/blog/2023-03-08-ethereum-classics-focus-on-trust-minimization/index.md
@@ -3,7 +3,7 @@ title: "Ethereum Classic's Focus on Trust Minimization"
 date: 2023-03-08
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-tags: ["Philosophy"]
+tags: ["philosophy"]
 linkImage: ./1.png
 ---
 

--- a/content/blog/2023-03-08-ethereum-classics-focus-on-trust-minimization/index.zh.md
+++ b/content/blog/2023-03-08-ethereum-classics-focus-on-trust-minimization/index.zh.md
@@ -3,7 +3,7 @@ title: "以太坊经典对信任最小化的关注"
 date: 2023-03-08
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-tags: ["Philosophy"]
+tags: ["philosophy"]
 linkImage: ./1.png
 ---
 


### PR DESCRIPTION
This article had the "Philosophy" tag with capital letter. It is fixed to "philosophy".