### PR TITLE
Adds promotional disclaimer for Spotlight articles

### DIFF
--- a/content/blog/2023-06-20-etc-ecosystem-spotlight-hebeswap-part-I/index.md
+++ b/content/blog/2023-06-20-etc-ecosystem-spotlight-hebeswap-part-I/index.md
@@ -3,6 +3,7 @@ title: "ETC Ecosystem Spotlight: HebeSwap Part I"
 date: 2023-06-20
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
+disclaimers: promotional
 tags: ["guide", "teams"]
 linkImage: ./banner.png
 ---

--- a/content/blog/2023-06-20-etc-ecosystem-spotlight-hebeswap-part-I/index.md
+++ b/content/blog/2023-06-20-etc-ecosystem-spotlight-hebeswap-part-I/index.md
@@ -3,7 +3,7 @@ title: "ETC Ecosystem Spotlight: HebeSwap Part I"
 date: 2023-06-20
 author: Donald McIntyre
 contributors: ["DonaldMcIntyre"]
-disclaimers: promotional
+disclaimer: promotional
 tags: ["guide", "teams"]
 linkImage: ./banner.png
 ---

--- a/content/ui.global.yaml
+++ b/content/ui.global.yaml
@@ -11,6 +11,9 @@ timeline:
   chronological: Chronological
   reversed: Reversed
 disclaimers:
+  promotional:
+    title: Promotional Content
+    text: This article may contain promotional material and information which is solely the opinion of the author. Ethereum Classic and this website do not endorse any product, service, or entity.   
   verify:
     title: Don't Trust, Verify.
     text: External links are unofficial community submissions.

--- a/content/ui.global.yaml
+++ b/content/ui.global.yaml
@@ -13,7 +13,7 @@ timeline:
 disclaimers:
   promotional:
     title: Promotional Content
-    text: This article may contain promotional material and information which is solely the opinion of the author. Ethereum Classic and this website do not endorse any product, service, or entity.   
+    text: This article may contain promotional material and information that is solely the opinion of the author. Ethereum Classic and this website do not endorse any product, service, or entity.   
   verify:
     title: Don't Trust, Verify.
     text: External links are unofficial community submissions.


### PR DESCRIPTION
This PR is intended to provide an additional option regarding the publication of articles and material that could be considered as promoting a particular product, service, or entity.

Currently, there are apparently only two options available to maintainers: 1) approve whatever @DonaldMcIntyre  submits without modification,  or 2) block whatever submissions @gitr0n1n does not want to be introduced This is an attempt to create a path to publication for information that many would find valuable while maintaining the neutrality of the publisher (this website).

Added is a disclaimer on the article header similar to that already in use for Opinionated Content. 

This PR also applies the disclaimer option to the Spotlight article on HebeBlock which is already merged.