### PR TITLE
Update index.md - changing the Mordor RPC URL to the new one.

### DIFF
--- a/content/blog/2023-06-13-using-the-etc-testnet-mordor/index.md
+++ b/content/blog/2023-06-13-using-the-etc-testnet-mordor/index.md
@@ -102,7 +102,7 @@ https://ethereumclassic.org/network/endpoints
 
 The most commonly used endpoint to access Mordor is provided by the ETC Cooperative and it is the following:
 
-https://www.ethercluster.com/mordor
+https://rpc.mordor.etccooperative.org/
 
 ## Getting Mordor Coins for Testing and Paying Transaction Fees
 


### PR DESCRIPTION
Changing the Mordor RPC endpoint in the article from Ethercluster to ETC Coop's new endpoint: https://rpc.mordor.etccooperative.org/.