### PR TITLE
Update index.yaml - Change Mordor endpoint

### DIFF
--- a/content/network/endpoints/index.yaml
+++ b/content/network/endpoints/index.yaml
@@ -36,8 +36,8 @@ items:
         __link: https://rivet.link
         __name: ETC Cooperative
       ETC Cooperative (Mordor):
-        __rpcUrl: https://www.ethercluster.com/mordor
-        __link: https://www.ethercluster.com
+        __rpcUrl: https://rpc.mordor.etccooperative.org/
+        __link: https://etccooperative.org
         __name: ETC Cooperative (Mordor)
       HebeBlock:
         __rpcUrl: https://etc.etcdesktop.com/


### PR DESCRIPTION
This PR changes the Mordor endpoint from Ethercluster to rpc.mordor.etccooperative.org.