### PR TITLE
Update ETC Mordor RPC endpoint

### DIFF
--- a/content/network/endpoints/index.yaml
+++ b/content/network/endpoints/index.yaml
@@ -36,8 +36,8 @@ items:
         __link: https://rivet.link
         __name: ETC Cooperative
       ETC Cooperative (Mordor):
-        __rpcUrl: https://www.ethercluster.com/mordor
-        __link: https://www.ethercluster.com
+        __rpcUrl: https://rpc.mordor.etccooperative.org
+        __link: https://www.etccooperative.org
         __name: ETC Cooperative (Mordor)
       HebeBlock:
         __rpcUrl: https://etc.etcdesktop.com/

--- a/i18n/network/endpoints/index.aa.yaml
+++ b/i18n/network/endpoints/index.aa.yaml
@@ -28,8 +28,8 @@ items:
         __link: https://rivet.link
         __name: ETC Cooperative
       ETC Cooperative (Mordor):
-        __rpcUrl: https://www.ethercluster.com/mordor
-        __link: https://www.ethercluster.com
+        __rpcUrl: https://rpc.mordor.etccooperative.org
+        __link: https://www.etccooperative.org
         __name: ETC Cooperative (Mordor)
       HebeBlock:
         __rpcUrl: https://etc.etcdesktop.com/


### PR DESCRIPTION
Starting from July 24th, 2023 the current endpoint will be disabled. This commit replaces it with the one listed in the announcement post, https://etccooperative.org/posts/2023-06-24-important-announcement-migrate-the-etc-and-mordor-rpc-endpoints-by-july-24-2023-en