### PR TITLE
Correct Title ETC-Network.Info Post

### DIFF
--- a/content/blog/2023-11-01-etc-spotlight-etc-network-info-with-mario-michel/index.md
+++ b/content/blog/2023-11-01-etc-spotlight-etc-network-info-with-mario-michel/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ETC Spotlight: ETC-Network.Info With Mario Michel"
+title: "ETC Ecosystem Spotlight: ETC-Network.Info With Mario Michel"
 date: 2023-11-01
 author: Donald McIntyre
 contributors: ["Donald McIntyre"]

--- a/content/blog/2023-11-01-etc-spotlight-etc-network-info-with-mario-michel/index.zh.md
+++ b/content/blog/2023-11-01-etc-spotlight-etc-network-info-with-mario-michel/index.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "聚焦ETC：与Mario Michel讨论ETC-Network.Info"
+title: "ETC 生态系统聚焦：Mario Michel 的 ETC-Network.Info"
 date: 2023-11-01
 author: Donald McIntyre
 contributors: ["Donald McIntyre"]


### PR DESCRIPTION
This PR corrects the title of the ETC-Network.Info to add the term "Ecosystem" as in "ETC Ecosystem Spotlight". It does this for both the EN and CN versions. 