### PR TITLE
Add 3xpl and Blockchair explorers

### DIFF
--- a/content/network/explorers/index.yaml
+++ b/content/network/explorers/index.yaml
@@ -7,6 +7,7 @@ __contributors:
   - cicorias
   - dax-classix
   - gitr0n1n
+  - Har01d
   - IstoraMandiri
   - ProphetDaniel
   - pyskell
@@ -32,6 +33,12 @@ items:
         __linkRef: mordor
         text: Mordor
     items:
+      3xpl:
+        __name: 3xpl
+        __etc: https://3xpl.com/ethereum-classic
+      Blockchair:
+        __name: Blockchair
+        __etc: https://blockchair.com/ethereum-classic
       BlockScout:
         __name: BlockScout
         __etc: https://blockscout.com/etc/mainnet/


### PR DESCRIPTION
There are two new explorers available for Ethereum Classic:

- https://3xpl.com/ethereum-classic
- https://blockchair.com/ethereum-classic

Besides an ad-free web explorer, 3xpl offers a variety of APIs, charts and free dataset dumps.

Blockchair is currently using 3xpl's engine, and it's planned that it will include more blockchain-specific data similar to the existing Ethereum explorer.