### PR TITLE
Remove ETCSwap news links

### DIFF
--- a/content/news/links.collection.en.yaml
+++ b/content/news/links.collection.en.yaml
@@ -1,25 +1,3 @@
-- date: 2024-05-14
-  title: "ETC Ecosystem Spotlight: USD-Backed 'USC' Stablecoin"
-  link: https://ethereumclassic.com/news/2024/05/14/introducing-ethereum-classic-usd-backed-usc-stablecoin/
-  author: Ethereum Classic DAO
-  source: EthereumClassic.com
-  tags:
-    - announcement
-    - development
-    - education
-    - exchange
-    - guide
-- date: 2024-05-13
-  title: "ETC Ecosystem Spotlight: ETCswap v3"
-  link: https://ethereumclassic.com/news/2024/05/06/introducing-etcswap-v3/
-  author: Ethereum Classic DAO
-  source: EthereumClassic.com
-  tags:
-    - announcement
-    - development
-    - education
-    - exchange
-    - guide
 - date: 2023-07-06
   title: "Draft ECIP 1109: Spiral EVM and Protocol Upgrades"
   link: https://ecips.ethereumclassic.org/ECIPs/ecip-1109


### PR DESCRIPTION
Still waiting on spotlight articles from @gitr0n1n , so please merge this in the meantime.

This keeps them in the apps section rather than reverting that  part (#1517)

Form this commit, here spotlight articles can be added, but should follow the same format as other Spotlight posts.