### PR TITLE
Limit RSS to 100 items

### DIFF
--- a/configs/rss.js
+++ b/configs/rss.js
@@ -14,6 +14,7 @@ module.exports = ({ locales, defaultLocale, siteUrl }) => ({
         newsItems: allNewsItem(
           filter: { locale: { eq: "${key}" }, unlisted: { ne: true } }
           sort: { fields: [date, title], order: [DESC, ASC] }
+          limit: 100
         ) {
           edges {
             node {


### PR DESCRIPTION
The [RSS feed](https://ethereumclassic.org/rss.xml) grew to a huge 1mb in file size, which may be contributing to unnecessary bandwidth usage especially if many bots are scraping this frequently.

This PR limits to 100 items, so should largely reduce bandwidth usage.