### PR TITLE
Swap highlighted Discord room

### DIFF
--- a/content/ui.global.yaml
+++ b/content/ui.global.yaml
@@ -68,14 +68,14 @@ signOff: Made with `<3` for the Original Ethereum Vision
 socialHilight: The ETC community is active on Discord
 socialItems:
   discord:
-    __link: https://discord.com/invite/Tq57jxSwsa
+    __link: https://discord.com/invite/hQs894U
     __icon: discord
     __hilight: 1
     name: Discord
-  discordLegacy:
-    __link: https://discord.com/invite/hQs894U
+  discordOlympia:
+    __link: https://discord.com/invite/Tq57jxSwsa
     __icon: discord
-    name: Legacy Discord
+    name: Olympia Discord
   twitterEthclassic:
     __link: https://twitter.com/eth_classic
     __icon: twitter


### PR DESCRIPTION
The original motivation for switching #1648 was bot spam on the legacy server, but that's no longer the case. 

Recently the newer Discord server has seen essentially no activity, including from it's admins, while the legacy server remains the active hub of community discussion. With the recent Olympia events, it makes sense to point newcomers at the room where conversation actually happens.

This PR re-highlights the active server as **Discord** and demotes the newer invite to **Olympia Discord**, keeping it accessible but no longer the featured link.

Rel: #1675 