### PR TITLE
exchanges: add EIDEX to cross-chain swap exchanges

### DIFF
--- a/content/services/exchanges/index.yaml
+++ b/content/services/exchanges/index.yaml
@@ -442,6 +442,9 @@ items:
       Cyphergoat:
         __link: https://cyphergoat.com
         __name: CypherGoat
+      EIDEX:
+        __link: https://eidex.io/screener
+        __name: EIDEX
       Emerald:
         __link: https://emerald.cash/
         __name: Emerald


### PR DESCRIPTION
Adds EIDEX to the Cross-Chain Swap Exchanges section.

EIDEX is a non-custodial cross-chain route aggregator with no registration required. It compares live ETC rates across 30+ swap providers - including ChangeNOW, Exolix, FixedFloat, SimpleSwap, StealthEX and SwapSpace already listed here - and routes the user to whichever source offers the best terms.

Entry added alphabetically between Cyphergoat and Emerald.