### PR TITLE
Make Footer Social Links More Neutral

### DIFF
--- a/content/community/channels/index.yaml
+++ b/content/community/channels/index.yaml
@@ -15,27 +15,65 @@ __contributors:
   - redsn0w0
   - TheEnthusiasticAs
   - w1g0
-__updated: 2022-02-22
+__updated: 2026-09-02
 seo: A collection of Ethereum Classic chat rooms, Twitter accounts, discussion groups, forums, podcasts, repositories and regional websites.
 description: |
-  The following is a non-exhaustive list of active Ethereum Classic discussion channels and groups.
+  Ethereum Classic has no central organisation, and therefore no "official" social media; every channel listed here is run independently by members of the community.
 
-  The main hub of activity within the ETC community at present is on [Discord](https://ethereumclassic.org/discord).
+  The Discord, Telegram, Twitter and Reddit sections cover the channels linked in the footer of this website. The rest is a non-exhaustive directory of regional and topic specific groups; parts of it have not been reviewed in a while, so some links may be out of date.
 items:
+  discord:
+    __type: cells
+    title: Discord
+    description: |
+      There are two general purpose ETC Discord servers, both active. They are listed in the order they were created, without preference; feel free to join whichever suits you, or both.
+    items:
+      discordClassic:
+        __link: https://discord.com/invite/hQs894U
+        name: Ethereum Classic Discord
+        description: The original community server, running since 2016, and the venue for many of the past core devs calls and community calls.
+      discordCommunity:
+        __link: https://discord.com/invite/Tq57jxSwsa
+        name: Ethereum Classic Community Discord
+        description: A newer server, launched in November 2025, which is more tightly moderated and runs automated verification, anti-spam and announcement integrations. See the [announcement post](/blog/2025-11-05-discord-migration) for background.
+  telegram:
+    __type: cells
+    title: Telegram
+    items:
+      telegramGrantsDao:
+        __link: https://t.me/ETCGrantsDao
+        name: ETC Grants DAO
+        description: The group around [ETC Grants DAO](https://etcgrantsdao.io), which funds projects building on Ethereum Classic. It is one of the busiest ETC chats, with many active users discussing the ecosystem day to day.
+      telegramEnglish:
+        __link: https://t.me/ethclassic
+        name: Ethereum Classic (English)
+        description: The long-running English language group for general ETC chat.
+  twitter:
+    __type: cells
+    title: Twitter
+    description: |
+      The two main community accounts are run through [twitter-together](https://github.com/twitter-together/action); tweets are proposed as pull requests against the account's repository, reviewed in the open, and posted automatically once merged. The easiest way to suggest one is the [ETC Contributions app](https://etc.contributions.app), which submits the pull request for you, with or without a GitHub account. Ideas are also picked up from tweets tagged `#ETCtweets`, which are discussed in the `#ETCtweets` Discord thread.
+    items:
+      twitterEthClassic:
+        __link: https://twitter.com/eth_classic
+        __name: "@eth_classic"
+        description: The more widely followed of the two accounts, with editorial guidelines that keep it formal, neutral and free of memes. Tweets are proposed in [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).
+      twitterEtcNetwork:
+        __link: https://twitter.com/ETC_Network
+        __name: "@ETC_Network"
+        description: A less formal account where memes and lighter posts are permitted alongside network and development updates. Tweets are proposed in [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).
+  reddit:
+    __type: cells
+    title: Reddit
+    items:
+      redditEthereumClassic:
+        __link: https://reddit.com/r/ethereumclassic
+        __name: r/EthereumClassic
+        description: The Ethereum Classic subreddit, used for longer form discussion, questions, and sharing news and links from around the ecosystem.
   Chat Rooms:
     __type: buttons
-    title: Chat Rooms
+    title: Other Chat Rooms
     items:
-      chat Discord:
-        __link: https://ethereumclassic.org/discord
-        __icon: discord
-        __primary: 1
-        name: Discord (Community, Global)
-      chat Discord Coop:
-        __link: https://discord.gg/5wDyd6u6pU
-        __icon: discord
-        __primary: 1
-        name: Discord (ETC Coop)
       chat Facebook English:
         __link: https://www.facebook.com/groups/ethereum.hongkong/
         __icon: facebook
@@ -71,12 +109,8 @@ items:
         name: Hyperledger Besu
   Telegram Groups:
     __type: buttons
-    title: Telegram Groups
+    title: Regional Telegram Groups
     items:
-      telegram English:
-        __link: https://t.me/ethclassic
-        __icon: telegram
-        name: English
       telegram Español:
         __link: https://t.me/ethclassicesp
         __icon: telegram
@@ -99,12 +133,8 @@ items:
         name: 中文
   Forums:
     __type: buttons
-    title: Forums
+    title: Other Forums
     items:
-      forum RedditEthereumClassic:
-        __link: https://www.reddit.com/r/EthereumClassic/
-        __icon: reddit
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         __link: https://bitcointalk.org/index.php?topic=5134923
         __icon: news
@@ -151,22 +181,12 @@ items:
         name: Let's Talk ETC!
   Twitter Accounts:
     __type: buttons
-    title: Twitter Accounts
+    title: Regional Twitter Accounts
     items:
       twitter China:
         __link: https://twitter.com/EthereumChina
         __icon: twitter
         name: China
-      twitter English 1:
-        __link: https://twitter.com/ETC_Network
-        __icon: twitter
-        __primary: 1
-        name: "@ETC_Network"
-      twitter English 2:
-        __link: https://twitter.com/eth_classic
-        __icon: twitter
-        __primary: 1
-        name: "@eth_classic"
       twitter Español:
         __link: https://twitter.com/ethclassicesp
         __icon: twitter

--- a/content/community/channels/index.yaml
+++ b/content/community/channels/index.yaml
@@ -15,7 +15,7 @@ __contributors:
   - redsn0w0
   - TheEnthusiasticAs
   - w1g0
-__updated: 2026-09-02
+__updated: 2026-09-07
 seo: A collection of Ethereum Classic chat rooms, Twitter accounts, discussion groups, forums, podcasts, repositories and regional websites.
 description: |
   Ethereum Classic has no central organisation, and therefore no "official" social media; every channel listed here is run independently by members of the community.
@@ -31,28 +31,28 @@ items:
       discordClassic:
         __link: https://discord.com/invite/hQs894U
         name: Ethereum Classic Discord
-        description: The original community server, running since 2016, and the venue for many of the past core devs calls and community calls.
+        description: The original community server, running since 2016, which is loosely moderated and was the venue for many of the past core devs calls and community calls.
       discordCommunity:
         __link: https://discord.com/invite/Tq57jxSwsa
         name: Ethereum Classic Community Discord
-        description: A newer server, launched in November 2025, which is more tightly moderated and runs automated verification, anti-spam and announcement integrations. See the [announcement post](/blog/2025-11-05-discord-migration) for background.
+        description: A newer server, launched in November 2025, which is tightly moderated and runs automated verification, anti-spam and announcement integrations. See the [announcement post](/blog/2025-11-05-discord-migration) for background.
   telegram:
     __type: cells
     title: Telegram
     items:
-      telegramGrantsDao:
-        __link: https://t.me/ETCGrantsDao
-        name: ETC Grants DAO
-        description: The group around [ETC Grants DAO](https://etcgrantsdao.io), which funds projects building on Ethereum Classic. It is one of the busiest ETC chats, with many active users discussing the ecosystem day to day.
       telegramEnglish:
         __link: https://t.me/ethclassic
         name: Ethereum Classic (English)
         description: The long-running English language group for general ETC chat.
+      telegramGrantsDao:
+        __link: https://t.me/ETCGrantsDao
+        name: ETC Grants DAO
+        description: The group around [ETC Grants DAO](https://etcgrantsdao.io), which funds projects building on Ethereum Classic.
   twitter:
     __type: cells
     title: Twitter
     description: |
-      The two main community accounts are run through [twitter-together](https://github.com/twitter-together/action); tweets are proposed as pull requests against the account's repository, reviewed in the open, and posted automatically once merged. The easiest way to suggest one is the [ETC Contributions app](https://etc.contributions.app), which submits the pull request for you, with or without a GitHub account. Ideas are also picked up from tweets tagged `#ETCtweets`, which are discussed in the `#ETCtweets` Discord thread.
+      The two community-run accounts use [twitter-together](https://github.com/twitter-together/action); tweets are proposed as pull requests against the account's repository, reviewed in the open, and posted automatically once merged. The easiest way to suggest one is the [ETC Contributions app](https://etc.contributions.app), which submits the pull request for you, with or without a GitHub account. Ideas are also picked up from tweets tagged `#ETCtweets`, which are discussed in the `#ETCtweets` Discord thread.
     items:
       twitterEthClassic:
         __link: https://twitter.com/eth_classic

--- a/content/ui.global.yaml
+++ b/content/ui.global.yaml
@@ -68,34 +68,26 @@ signOff: Made with `<3` for the Original Ethereum Vision
 socialHilight: The ETC community is active on Discord
 socialItems:
   discord:
-    __link: https://discord.com/invite/Tq57jxSwsa
+    __link: /community/channels
     __icon: discord
     __hilight: 1
     name: Discord
-  discordLegacy:
-    __link: https://discord.com/invite/hQs894U
-    __icon: discord
-    name: Legacy Discord
-  twitterEthclassic:
-    __link: https://twitter.com/eth_classic
+  telegram:
+    __link: /community/channels
+    __icon: telegram
+    name: Telegram
+  twitter:
+    __link: /community/channels
     __icon: twitter
-    name: eth_classic Twitter
-  twitterEtcnetwork:
-    __link: https://twitter.com/ETC_Network
-    __icon: twitter
-    name: ETC_Network Twitter
-  githubOrg:
-    __link: https://github.com/ethereumclassic
-    __icon: github
-    name: ETC Network Github
-  githubLabs:
-    __link: https://github.com/etclabscore
-    __icon: github
-    name: ETC Labs Github
+    name: Twitter
   reddit:
-    __link: https://reddit.com/r/ethereumclassic
+    __link: /community/channels
     __icon: reddit
     name: Reddit
+  github:
+    __link: https://github.com/ethereumclassic
+    __icon: github
+    name: Github
 appTypes:
   finance:
     __color: green

--- a/content/ui.global.yaml
+++ b/content/ui.global.yaml
@@ -87,7 +87,7 @@ socialItems:
   github:
     __link: https://github.com/ethereumclassic
     __icon: github
-    name: Github
+    name: GitHub
 appTypes:
   finance:
     __color: green
@@ -117,7 +117,7 @@ appLinks:
   homepage: Homepage
   app: App Site
   twitter: Twitter
-  github: Github
+  github: GitHub
 newsTypes:
   news:
     name: Link

--- a/i18n/community/channels/index.aa.yaml
+++ b/i18n/community/channels/index.aa.yaml
@@ -15,25 +15,63 @@ __contributors:
   - redsn0w0
   - TheEnthusiasticAs
   - w1g0
-__updated: 2022-02-22
+__updated: 2026-09-02
 seo: crwdns119061:0crwdne119061:0
 description: |
   crwdns119063:0crwdne119063:0
 items:
+  discord:
+    __type: cells
+    title: crwdns119351:0crwdne119351:0
+    description: |
+      crwdns119357:0crwdne119357:0
+    items:
+      discordClassic:
+        __link: https://discord.com/invite/hQs894U
+        name: crwdns119363:0crwdne119363:0
+        description: crwdns119369:0crwdne119369:0
+      discordCommunity:
+        __link: https://discord.com/invite/Tq57jxSwsa
+        name: crwdns119375:0crwdne119375:0
+        description: crwdns119381:0crwdne119381:0
+  telegram:
+    __type: cells
+    title: crwdns119387:0crwdne119387:0
+    items:
+      telegramGrantsDao:
+        __link: https://t.me/ETCGrantsDao
+        name: crwdns119393:0crwdne119393:0
+        description: crwdns119399:0crwdne119399:0
+      telegramEnglish:
+        __link: https://t.me/ethclassic
+        name: crwdns119405:0crwdne119405:0
+        description: crwdns119411:0crwdne119411:0
+  twitter:
+    __type: cells
+    title: crwdns119417:0crwdne119417:0
+    description: |
+      crwdns119423:0crwdne119423:0
+    items:
+      twitterEthClassic:
+        __link: https://twitter.com/eth_classic
+        __name: '@eth_classic'
+        description: crwdns119429:0crwdne119429:0
+      twitterEtcNetwork:
+        __link: https://twitter.com/ETC_Network
+        __name: '@ETC_Network'
+        description: crwdns119435:0crwdne119435:0
+  reddit:
+    __type: cells
+    title: crwdns119441:0crwdne119441:0
+    items:
+      redditEthereumClassic:
+        __link: https://reddit.com/r/ethereumclassic
+        __name: r/EthereumClassic
+        description: crwdns119447:0crwdne119447:0
   Chat Rooms:
     __type: buttons
     title: crwdns119067:0crwdne119067:0
     items:
-      chat Discord:
-        __link: https://ethereumclassic.org/discord
-        __icon: discord
-        __primary: 1
-        name: crwdns119075:0crwdne119075:0
-      chat Discord Coop:
-        __link: https://discord.gg/5wDyd6u6pU
-        __icon: discord
-        __primary: 1
-        name: crwdns119083:0crwdne119083:0
       chat Facebook English:
         __link: https://www.facebook.com/groups/ethereum.hongkong/
         __icon: facebook
@@ -71,10 +109,6 @@ items:
     __type: buttons
     title: crwdns119133:0crwdne119133:0
     items:
-      telegram English:
-        __link: https://t.me/ethclassic
-        __icon: telegram
-        name: crwdns119139:0crwdne119139:0
       telegram Español:
         __link: https://t.me/ethclassicesp
         __icon: telegram
@@ -99,10 +133,6 @@ items:
     __type: buttons
     title: crwdns119173:0crwdne119173:0
     items:
-      forum RedditEthereumClassic:
-        __link: https://www.reddit.com/r/EthereumClassic/
-        __icon: reddit
-        name: crwdns119179:0crwdne119179:0
       forum BitcoinTalk:
         __link: https://bitcointalk.org/index.php?topic=5134923
         __icon: news
@@ -155,16 +185,6 @@ items:
         __link: https://twitter.com/EthereumChina
         __icon: twitter
         name: crwdns119253:0crwdne119253:0
-      twitter English 1:
-        __link: https://twitter.com/ETC_Network
-        __icon: twitter
-        __primary: 1
-        name: "crwdns119261:0crwdne119261:0"
-      twitter English 2:
-        __link: https://twitter.com/eth_classic
-        __icon: twitter
-        __primary: 1
-        name: "crwdns119269:0crwdne119269:0"
       twitter Español:
         __link: https://twitter.com/ethclassicesp
         __icon: twitter

--- a/i18n/community/channels/index.aa.yaml
+++ b/i18n/community/channels/index.aa.yaml
@@ -15,7 +15,7 @@ __contributors:
   - redsn0w0
   - TheEnthusiasticAs
   - w1g0
-__updated: 2026-09-02
+__updated: 2026-09-07
 seo: crwdns119061:0crwdne119061:0
 description: |
   crwdns119063:0crwdne119063:0
@@ -38,14 +38,14 @@ items:
     __type: cells
     title: crwdns119387:0crwdne119387:0
     items:
-      telegramGrantsDao:
-        __link: https://t.me/ETCGrantsDao
-        name: crwdns119393:0crwdne119393:0
-        description: crwdns119399:0crwdne119399:0
       telegramEnglish:
         __link: https://t.me/ethclassic
         name: crwdns119405:0crwdne119405:0
         description: crwdns119411:0crwdne119411:0
+      telegramGrantsDao:
+        __link: https://t.me/ETCGrantsDao
+        name: crwdns119393:0crwdne119393:0
+        description: crwdns119399:0crwdne119399:0
   twitter:
     __type: cells
     title: crwdns119417:0crwdne119417:0

--- a/i18n/community/channels/index.ar.yaml
+++ b/i18n/community/channels/index.ar.yaml
@@ -1,17 +1,43 @@
 title: القنوات الاجتماعية
 seo: مجموعة من غرف الدردشة Ethereum Classic وحسابات Twitter ومجموعات المناقشة والمنتديات والبودكاست والمستودعات ومواقع الويب الإقليمية.
 description: |
-  فيما يلي قائمة غير شاملة بقنوات ومجموعات مناقشة Ethereum Classic النشطة.
+  لا توجد لدى Ethereum Classic منظمة مركزية، وبالتالي لا توجد حسابات تواصل اجتماعي «رسمية»؛ فكل قناة مذكورة هنا يديرها أفراد من المجتمع بشكل مستقل.
 
-  المحور الرئيسي للنشاط داخل مجتمع ETC في الوقت الحالي هو [Discord](https://ethereumclassic.org/discord).
+  تغطي أقسام Discord وTelegram وTwitter وReddit القنوات المرتبطة في تذييل هذا الموقع. أما البقية فهي دليل غير شامل للمجموعات الإقليمية والمتخصصة؛ لم تُراجَع بعض أجزائه منذ فترة، لذا قد تكون بعض الروابط قديمة.
 items:
-  Chat Rooms:
-    title: غرف الدردشة
+  discord:
+    description: |
+      يوجد خادمان عامّان لـ ETC على Discord، وكلاهما نشط. وهما مرتَّبان حسب تاريخ الإنشاء دون تفضيل أيٍّ منهما؛ يمكنك الانضمام إلى ما يناسبك، أو إليهما معًا.
     items:
-      chat Discord:
-        name: الفتنة (مجتمع ، عالمي)
-      chat Discord Coop:
-        name: Discord (ETC Coop)
+      discordClassic:
+        name: خادم Ethereum Classic على Discord
+        description: الخادم المجتمعي الأصلي، ويعمل منذ عام 2016، وقد استضاف كثيرًا من مكالمات المطورين الأساسيين ومكالمات المجتمع السابقة.
+      discordCommunity:
+        name: خادم مجتمع Ethereum Classic على Discord
+        description: 'خادم أحدث، أُطلق في نوفمبر 2025، ويخضع لإشراف أكثر صرامة، ويعتمد على التحقق التلقائي والحماية من الرسائل المزعجة وتكاملات الإعلانات. راجع [منشور الإعلان](/blog/2025-11-05-discord-migration) للاطلاع على الخلفية.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'المجموعة المحيطة بـ [ETC Grants DAO](https://etcgrantsdao.io)، التي تموّل المشاريع المبنية على Ethereum Classic. وهي من أكثر محادثات ETC نشاطًا، ويشارك فيها كثير من المستخدمين النشطين الذين يناقشون المنظومة يوميًا.'
+      telegramEnglish:
+        name: Ethereum Classic (بالإنجليزية)
+        description: المجموعة الإنجليزية العريقة للحديث العام عن ETC.
+  twitter:
+    description: |
+      يعمل الحسابان المجتمعيان الرئيسيان عبر [twitter-together](https://github.com/twitter-together/action): تُقترح التغريدات على شكل طلبات سحب في مستودع الحساب، وتُراجَع علنًا، ثم تُنشر تلقائيًا بعد دمجها. وأسهل طريقة لاقتراح تغريدة هي [تطبيق مساهمات ETC](https://etc.contributions.app)، الذي يقدّم طلب السحب نيابةً عنك، سواء كان لديك حساب على GitHub أم لا. كما تُستقى الأفكار من التغريدات الموسومة بـ `#ETCtweets`، وتُناقش في سلسلة `#ETCtweets` على Discord.
+    items:
+      twitterEthClassic:
+        description: 'الحساب الأكثر متابعة من بين الاثنين، وتحافظ إرشاداته التحريرية على طابع رسمي ومحايد وخالٍ من الميمات. تُقترح التغريدات في [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'حساب أقل رسمية، تُسمح فيه الميمات والمنشورات الخفيفة إلى جانب أخبار الشبكة والتطوير. تُقترح التغريدات في [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: منتدى Ethereum Classic الفرعي على Reddit، ويُستخدم للنقاشات المطوّلة والأسئلة ومشاركة الأخبار والروابط من مختلف أنحاء المنظومة.
+  Chat Rooms:
+    title: غرف دردشة أخرى
+    items:
       chat Facebook English:
         name: الفيسبوك (الإنجليزية)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: هايبرليدجر بيسو
   Telegram Groups:
-    title: مجموعات Telegram
+    title: مجموعات Telegram الإقليمية
     items:
-      telegram English:
-        name: إنجليزي
       telegram Español:
         name: الاسبانية
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: المنتديات
+    title: منتديات أخرى
     items:
-      forum RedditEthereumClassic:
-        name: رديت ص / EthereumClassic
       forum BitcoinTalk:
         name: بيتكوين توك
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: دعنا نتحدث إلخ!
   Twitter Accounts:
-    title: حسابات تويتر
+    title: حسابات Twitter الإقليمية
     items:
       twitter China:
         name: الصين
-      twitter English 1:
-        name: "ETC_Network"
-      twitter English 2:
-        name: "تضمين التغريدة"
       twitter Español:
         name: الاسبانية
       twitter France:

--- a/i18n/community/channels/index.ar.yaml
+++ b/i18n/community/channels/index.ar.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: خادم Ethereum Classic على Discord
-        description: الخادم المجتمعي الأصلي، ويعمل منذ عام 2016، وقد استضاف كثيرًا من مكالمات المطورين الأساسيين ومكالمات المجتمع السابقة.
+        description: الخادم المجتمعي الأصلي، ويعمل منذ عام 2016، ويخضع لإشراف خفيف، وقد استضاف كثيرًا من مكالمات المطورين الأساسيين ومكالمات المجتمع السابقة.
       discordCommunity:
         name: خادم مجتمع Ethereum Classic على Discord
-        description: 'خادم أحدث، أُطلق في نوفمبر 2025، ويخضع لإشراف أكثر صرامة، ويعتمد على التحقق التلقائي والحماية من الرسائل المزعجة وتكاملات الإعلانات. راجع [منشور الإعلان](/blog/2025-11-05-discord-migration) للاطلاع على الخلفية.'
+        description: 'خادم أحدث، أُطلق في نوفمبر 2025، ويخضع لإشراف صارم، ويعتمد على التحقق التلقائي والحماية من الرسائل المزعجة وتكاملات الإعلانات. راجع [منشور الإعلان](/blog/2025-11-05-discord-migration) للاطلاع على الخلفية.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'المجموعة المحيطة بـ [ETC Grants DAO](https://etcgrantsdao.io)، التي تموّل المشاريع المبنية على Ethereum Classic. وهي من أكثر محادثات ETC نشاطًا، ويشارك فيها كثير من المستخدمين النشطين الذين يناقشون المنظومة يوميًا.'
       telegramEnglish:
         name: Ethereum Classic (بالإنجليزية)
         description: المجموعة الإنجليزية العريقة للحديث العام عن ETC.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'المجموعة المحيطة بـ [ETC Grants DAO](https://etcgrantsdao.io)، التي تموّل المشاريع المبنية على Ethereum Classic.'
   twitter:
     description: |
-      يعمل الحسابان المجتمعيان الرئيسيان عبر [twitter-together](https://github.com/twitter-together/action): تُقترح التغريدات على شكل طلبات سحب في مستودع الحساب، وتُراجَع علنًا، ثم تُنشر تلقائيًا بعد دمجها. وأسهل طريقة لاقتراح تغريدة هي [تطبيق مساهمات ETC](https://etc.contributions.app)، الذي يقدّم طلب السحب نيابةً عنك، سواء كان لديك حساب على GitHub أم لا. كما تُستقى الأفكار من التغريدات الموسومة بـ `#ETCtweets`، وتُناقش في سلسلة `#ETCtweets` على Discord.
+      يعمل الحسابان اللذان يديرهما المجتمع عبر [twitter-together](https://github.com/twitter-together/action): تُقترح التغريدات على شكل طلبات سحب في مستودع الحساب، وتُراجَع علنًا، ثم تُنشر تلقائيًا بعد دمجها. وأسهل طريقة لاقتراح تغريدة هي [تطبيق مساهمات ETC](https://etc.contributions.app)، الذي يقدّم طلب السحب نيابةً عنك، سواء كان لديك حساب على GitHub أم لا. كما تُستقى الأفكار من التغريدات الموسومة بـ `#ETCtweets`، وتُناقش في سلسلة `#ETCtweets` على Discord.
     items:
       twitterEthClassic:
         description: 'الحساب الأكثر متابعة من بين الاثنين، وتحافظ إرشاداته التحريرية على طابع رسمي ومحايد وخالٍ من الميمات. تُقترح التغريدات في [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.de.yaml
+++ b/i18n/community/channels/index.de.yaml
@@ -1,17 +1,43 @@
 title: Soziale Kanäle
-seo: Eine Sammlung von Ethereum Classic-Chaträumen, Twitter-Konten, Diskussionsgruppen, Foren, Podcasts, Repositories und regionalen Websites.
+seo: 'Eine Sammlung von Ethereum Classic-Chaträumen, Twitter-Konten, Diskussionsgruppen, Foren, Podcasts, Repositories und regionalen Websites.'
 description: |
-  Im Folgenden finden Sie eine nicht erschöpfende Liste aktiver Ethereum Classic Diskussionskanäle und -gruppen.
+  Ethereum Classic hat keine zentrale Organisation und damit auch keine „offiziellen“ sozialen Medien; jeder hier aufgeführte Kanal wird unabhängig von Mitgliedern der Community betrieben.
 
-  Die Hauptaktivität innerhalb der ETC-Community findet derzeit auf [Discord](https://ethereumclassic.org/discord) statt.
+  Die Abschnitte Discord, Telegram, Twitter und Reddit umfassen die Kanäle, die in der Fußzeile dieser Website verlinkt sind. Der Rest ist ein nicht vollständiges Verzeichnis regionaler und themenspezifischer Gruppen; Teile davon wurden längere Zeit nicht überprüft, einige Links können also veraltet sein.
 items:
-  Chat Rooms:
-    title: Chat-Räume
+  discord:
+    description: |
+      Es gibt zwei allgemeine ETC-Discord-Server, beide aktiv. Sie sind in der Reihenfolge ihrer Entstehung aufgeführt, ohne Wertung; tritt gern dem bei, der dir zusagt, oder beiden.
     items:
-      chat Discord:
-        name: Discord (Gemeinschaft, Global)
-      chat Discord Coop:
-        name: Diskord (ETC Coop)
+      discordClassic:
+        name: Ethereum Classic Discord
+        description: 'Der ursprüngliche Community-Server, in Betrieb seit 2016, und Schauplatz vieler früherer Core-Devs-Calls und Community-Calls.'
+      discordCommunity:
+        name: Ethereum Classic Community Discord
+        description: 'Ein neuerer Server, gestartet im November 2025, der strenger moderiert wird und über automatische Verifizierung, Spamschutz und Ankündigungs-Integrationen verfügt. Hintergründe dazu im [Ankündigungsbeitrag](/blog/2025-11-05-discord-migration).'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Die Gruppe rund um die [ETC Grants DAO](https://etcgrantsdao.io), die Projekte auf Ethereum Classic finanziert. Sie ist einer der lebhaftesten ETC-Chats, mit vielen aktiven Nutzern, die das Ökosystem täglich diskutieren.'
+      telegramEnglish:
+        name: Ethereum Classic (Englisch)
+        description: Die langjährige englischsprachige Gruppe für allgemeine Gespräche über ETC.
+  twitter:
+    description: |
+      Die beiden wichtigsten Community-Konten laufen über [twitter-together](https://github.com/twitter-together/action): Tweets werden als Pull Requests im Repository des jeweiligen Kontos vorgeschlagen, offen geprüft und nach dem Merge automatisch veröffentlicht. Am einfachsten geht das über die [ETC-Contributions-App](https://etc.contributions.app), die den Pull Request für dich erstellt, mit oder ohne GitHub-Konto. Ideen werden außerdem aus Tweets mit dem Hashtag `#ETCtweets` aufgegriffen, die im `#ETCtweets`-Thread auf Discord besprochen werden.
+    items:
+      twitterEthClassic:
+        description: 'Das reichweitenstärkere der beiden Konten, mit redaktionellen Richtlinien, die es formell, neutral und frei von Memes halten. Tweets werden in [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) vorgeschlagen.'
+      twitterEtcNetwork:
+        description: 'Ein weniger formelles Konto, auf dem neben Netzwerk- und Entwicklungsnachrichten auch Memes und lockerere Beiträge erlaubt sind. Tweets werden in [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network) vorgeschlagen.'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Das Ethereum-Classic-Subreddit, für ausführlichere Diskussionen, Fragen und das Teilen von Neuigkeiten und Links aus dem gesamten Ökosystem.'
+  Chat Rooms:
+    title: Weitere Chaträume
+    items:
       chat Facebook English:
         name: Facebook (Englisch)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger-Besu
   Telegram Groups:
-    title: Telegramm-Gruppen
+    title: Regionale Telegram-Gruppen
     items:
-      telegram English:
-        name: Englisch
       telegram Español:
         name: Español
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Foren
+    title: Weitere Foren
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Lassen Sie uns über ETC reden!
   Twitter Accounts:
-    title: Twitter-Konten
+    title: Regionale Twitter-Konten
     items:
       twitter China:
         name: China
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Español
       twitter France:

--- a/i18n/community/channels/index.de.yaml
+++ b/i18n/community/channels/index.de.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Ethereum Classic Discord
-        description: 'Der ursprüngliche Community-Server, in Betrieb seit 2016, und Schauplatz vieler früherer Core-Devs-Calls und Community-Calls.'
+        description: 'Der ursprüngliche Community-Server, in Betrieb seit 2016, der locker moderiert wird und Schauplatz vieler früherer Core-Devs-Calls und Community-Calls war.'
       discordCommunity:
         name: Ethereum Classic Community Discord
-        description: 'Ein neuerer Server, gestartet im November 2025, der strenger moderiert wird und über automatische Verifizierung, Spamschutz und Ankündigungs-Integrationen verfügt. Hintergründe dazu im [Ankündigungsbeitrag](/blog/2025-11-05-discord-migration).'
+        description: 'Ein neuerer Server, gestartet im November 2025, der streng moderiert wird und über automatische Verifizierung, Spamschutz und Ankündigungs-Integrationen verfügt. Hintergründe dazu im [Ankündigungsbeitrag](/blog/2025-11-05-discord-migration).'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Die Gruppe rund um die [ETC Grants DAO](https://etcgrantsdao.io), die Projekte auf Ethereum Classic finanziert. Sie ist einer der lebhaftesten ETC-Chats, mit vielen aktiven Nutzern, die das Ökosystem täglich diskutieren.'
       telegramEnglish:
         name: Ethereum Classic (Englisch)
         description: Die langjährige englischsprachige Gruppe für allgemeine Gespräche über ETC.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Die Gruppe rund um die [ETC Grants DAO](https://etcgrantsdao.io), die Projekte auf Ethereum Classic finanziert.'
   twitter:
     description: |
-      Die beiden wichtigsten Community-Konten laufen über [twitter-together](https://github.com/twitter-together/action): Tweets werden als Pull Requests im Repository des jeweiligen Kontos vorgeschlagen, offen geprüft und nach dem Merge automatisch veröffentlicht. Am einfachsten geht das über die [ETC-Contributions-App](https://etc.contributions.app), die den Pull Request für dich erstellt, mit oder ohne GitHub-Konto. Ideen werden außerdem aus Tweets mit dem Hashtag `#ETCtweets` aufgegriffen, die im `#ETCtweets`-Thread auf Discord besprochen werden.
+      Die beiden von der Community betriebenen Konten nutzen [twitter-together](https://github.com/twitter-together/action): Tweets werden als Pull Requests im Repository des jeweiligen Kontos vorgeschlagen, offen geprüft und nach dem Merge automatisch veröffentlicht. Am einfachsten geht das über die [ETC-Contributions-App](https://etc.contributions.app), die den Pull Request für dich erstellt, mit oder ohne GitHub-Konto. Ideen werden außerdem aus Tweets mit dem Hashtag `#ETCtweets` aufgegriffen, die im `#ETCtweets`-Thread auf Discord besprochen werden.
     items:
       twitterEthClassic:
         description: 'Das reichweitenstärkere der beiden Konten, mit redaktionellen Richtlinien, die es formell, neutral und frei von Memes halten. Tweets werden in [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) vorgeschlagen.'

--- a/i18n/community/channels/index.el.yaml
+++ b/i18n/community/channels/index.el.yaml
@@ -1,17 +1,43 @@
 title: Κοινωνικά κανάλια
-seo: Μια συλλογή από Ethereum Classic chat rooms, λογαριασμούς Twitter, ομάδες συζήτησης, φόρουμ, podcasts, αποθετήρια και περιφερειακούς ιστότοπους.
+seo: 'Μια συλλογή από Ethereum Classic chat rooms, λογαριασμούς Twitter, ομάδες συζήτησης, φόρουμ, podcasts, αποθετήρια και περιφερειακούς ιστότοπους.'
 description: |
-  Ακολουθεί ένας μη εξαντλητικός κατάλογος των ενεργών καναλιών και ομάδων συζήτησης Ethereum Classic.
+  Το Ethereum Classic δεν έχει κεντρικό οργανισμό και επομένως δεν έχει «επίσημα» μέσα κοινωνικής δικτύωσης· κάθε κανάλι που αναφέρεται εδώ το διαχειρίζονται ανεξάρτητα μέλη της κοινότητας.
 
-  Ο κύριος κόμβος δραστηριότητας της κοινότητας ETC αυτή τη στιγμή είναι το [Discord](https://ethereumclassic.org/discord).
+  Οι ενότητες Discord, Telegram, Twitter και Reddit καλύπτουν τα κανάλια στα οποία παραπέμπει το υποσέλιδο αυτού του ιστότοπου. Τα υπόλοιπα είναι ένας μη εξαντλητικός κατάλογος τοπικών και θεματικών ομάδων· κάποια τμήματά του δεν έχουν ελεγχθεί εδώ και καιρό, οπότε ορισμένοι σύνδεσμοι μπορεί να είναι παρωχημένοι.
 items:
-  Chat Rooms:
-    title: Δωμάτια συνομιλίας
+  discord:
+    description: |
+      Υπάρχουν δύο διακομιστές Discord γενικού σκοπού για το ETC, και οι δύο ενεργοί. Παρατίθενται με τη σειρά που δημιουργήθηκαν, χωρίς προτίμηση· μπείτε σε όποιον σας ταιριάζει, ή και στους δύο.
     items:
-      chat Discord:
-        name: Discord (Κοινότητα, Παγκόσμια)
-      chat Discord Coop:
-        name: Discord (ETC Coop)
+      discordClassic:
+        name: Discord του Ethereum Classic
+        description: 'Ο αρχικός διακομιστής της κοινότητας, σε λειτουργία από το 2016, και ο χώρος όπου έγιναν πολλές από τις παλιότερες κλήσεις των core devs και της κοινότητας.'
+      discordCommunity:
+        name: Discord της κοινότητας Ethereum Classic
+        description: 'Ένας νεότερος διακομιστής, που ξεκίνησε τον Νοέμβριο του 2025, με αυστηρότερη εποπτεία, αυτόματη επαλήθευση, προστασία από ανεπιθύμητα μηνύματα και ενσωματώσεις ανακοινώσεων. Δείτε τη [δημοσίευση της ανακοίνωσης](/blog/2025-11-05-discord-migration) για το ιστορικό.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Η ομάδα γύρω από το [ETC Grants DAO](https://etcgrantsdao.io), που χρηματοδοτεί έργα πάνω στο Ethereum Classic. Είναι από τις πιο πολυσύχναστες συνομιλίες του ETC, με πολλούς ενεργούς χρήστες που συζητούν καθημερινά για το οικοσύστημα.'
+      telegramEnglish:
+        name: Ethereum Classic (αγγλικά)
+        description: Η μακροχρόνια αγγλόφωνη ομάδα για γενική συζήτηση περί ETC.
+  twitter:
+    description: |
+      Οι δύο βασικοί λογαριασμοί της κοινότητας λειτουργούν μέσω του [twitter-together](https://github.com/twitter-together/action): τα tweets προτείνονται ως pull requests στο αποθετήριο του λογαριασμού, ελέγχονται δημόσια και δημοσιεύονται αυτόματα μόλις ενσωματωθούν. Ο ευκολότερος τρόπος να προτείνετε ένα είναι η [εφαρμογή συνεισφορών ETC](https://etc.contributions.app), που υποβάλλει το pull request για εσάς, με ή χωρίς λογαριασμό GitHub. Ιδέες αντλούνται επίσης από tweets με την ετικέτα `#ETCtweets`, τα οποία συζητούνται στο νήμα `#ETCtweets` στο Discord.
+    items:
+      twitterEthClassic:
+        description: 'Ο πιο δημοφιλής από τους δύο λογαριασμούς, με συντακτικές οδηγίες που τον κρατούν τυπικό, ουδέτερο και χωρίς meme. Τα tweets προτείνονται στο [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Ένας λιγότερο τυπικός λογαριασμός, όπου επιτρέπονται meme και πιο ανάλαφρες αναρτήσεις παράλληλα με ενημερώσεις για το δίκτυο και την ανάπτυξη. Τα tweets προτείνονται στο [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Το subreddit του Ethereum Classic, για εκτενέστερες συζητήσεις, ερωτήσεις και για κοινοποίηση ειδήσεων και συνδέσμων από όλο το οικοσύστημα.'
+  Chat Rooms:
+    title: Άλλα δωμάτια συνομιλίας
+    items:
       chat Facebook English:
         name: Facebook (Αγγλικά)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Ομάδες Telegram
+    title: Τοπικές ομάδες Telegram
     items:
-      telegram English:
-        name: Αγγλικά
       telegram Español:
         name: Español
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Φόρουμ
+    title: Άλλα φόρουμ
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Ας μιλήσουμε ETC!
   Twitter Accounts:
-    title: Λογαριασμοί Twitter
+    title: Τοπικοί λογαριασμοί Twitter
     items:
       twitter China:
         name: Κίνα
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Español
       twitter France:

--- a/i18n/community/channels/index.el.yaml
+++ b/i18n/community/channels/index.el.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord του Ethereum Classic
-        description: 'Ο αρχικός διακομιστής της κοινότητας, σε λειτουργία από το 2016, και ο χώρος όπου έγιναν πολλές από τις παλιότερες κλήσεις των core devs και της κοινότητας.'
+        description: 'Ο αρχικός διακομιστής της κοινότητας, σε λειτουργία από το 2016, με χαλαρή εποπτεία, και ο χώρος όπου έγιναν πολλές από τις παλιότερες κλήσεις των core devs και της κοινότητας.'
       discordCommunity:
         name: Discord της κοινότητας Ethereum Classic
-        description: 'Ένας νεότερος διακομιστής, που ξεκίνησε τον Νοέμβριο του 2025, με αυστηρότερη εποπτεία, αυτόματη επαλήθευση, προστασία από ανεπιθύμητα μηνύματα και ενσωματώσεις ανακοινώσεων. Δείτε τη [δημοσίευση της ανακοίνωσης](/blog/2025-11-05-discord-migration) για το ιστορικό.'
+        description: 'Ένας νεότερος διακομιστής, που ξεκίνησε τον Νοέμβριο του 2025, με αυστηρή εποπτεία, αυτόματη επαλήθευση, προστασία από ανεπιθύμητα μηνύματα και ενσωματώσεις ανακοινώσεων. Δείτε τη [δημοσίευση της ανακοίνωσης](/blog/2025-11-05-discord-migration) για το ιστορικό.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Η ομάδα γύρω από το [ETC Grants DAO](https://etcgrantsdao.io), που χρηματοδοτεί έργα πάνω στο Ethereum Classic. Είναι από τις πιο πολυσύχναστες συνομιλίες του ETC, με πολλούς ενεργούς χρήστες που συζητούν καθημερινά για το οικοσύστημα.'
       telegramEnglish:
         name: Ethereum Classic (αγγλικά)
         description: Η μακροχρόνια αγγλόφωνη ομάδα για γενική συζήτηση περί ETC.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Η ομάδα γύρω από το [ETC Grants DAO](https://etcgrantsdao.io), που χρηματοδοτεί έργα πάνω στο Ethereum Classic.'
   twitter:
     description: |
-      Οι δύο βασικοί λογαριασμοί της κοινότητας λειτουργούν μέσω του [twitter-together](https://github.com/twitter-together/action): τα tweets προτείνονται ως pull requests στο αποθετήριο του λογαριασμού, ελέγχονται δημόσια και δημοσιεύονται αυτόματα μόλις ενσωματωθούν. Ο ευκολότερος τρόπος να προτείνετε ένα είναι η [εφαρμογή συνεισφορών ETC](https://etc.contributions.app), που υποβάλλει το pull request για εσάς, με ή χωρίς λογαριασμό GitHub. Ιδέες αντλούνται επίσης από tweets με την ετικέτα `#ETCtweets`, τα οποία συζητούνται στο νήμα `#ETCtweets` στο Discord.
+      Οι δύο λογαριασμοί που διαχειρίζεται η κοινότητα χρησιμοποιούν το [twitter-together](https://github.com/twitter-together/action): τα tweets προτείνονται ως pull requests στο αποθετήριο του λογαριασμού, ελέγχονται δημόσια και δημοσιεύονται αυτόματα μόλις ενσωματωθούν. Ο ευκολότερος τρόπος να προτείνετε ένα είναι η [εφαρμογή συνεισφορών ETC](https://etc.contributions.app), που υποβάλλει το pull request για εσάς, με ή χωρίς λογαριασμό GitHub. Ιδέες αντλούνται επίσης από tweets με την ετικέτα `#ETCtweets`, τα οποία συζητούνται στο νήμα `#ETCtweets` στο Discord.
     items:
       twitterEthClassic:
         description: 'Ο πιο δημοφιλής από τους δύο λογαριασμούς, με συντακτικές οδηγίες που τον κρατούν τυπικό, ουδέτερο και χωρίς meme. Τα tweets προτείνονται στο [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.es.yaml
+++ b/i18n/community/channels/index.es.yaml
@@ -1,17 +1,43 @@
 title: Canales sociales
-seo: Una colección de salas de chat de Ethereum Classic, cuentas de Twitter, grupos de discusión, foros, podcasts, repositorios y sitios web regionales.
+seo: 'Una colección de salas de chat de Ethereum Classic, cuentas de Twitter, grupos de discusión, foros, podcasts, repositorios y sitios web regionales.'
 description: |
-  La siguiente es una lista no exhaustiva de los canales y grupos de debate activos de Ethereum Classic.
+  Ethereum Classic no tiene una organización central y, por tanto, tampoco tiene redes sociales «oficiales»; cada canal que aparece aquí lo gestionan de forma independiente miembros de la comunidad.
 
-  El principal centro de actividad de la comunidad ETC en la actualidad es [Discord](https://ethereumclassic.org/discord).
+  Las secciones de Discord, Telegram, Twitter y Reddit recogen los canales enlazados en el pie de página de este sitio. El resto es un directorio no exhaustivo de grupos regionales y temáticos; hace tiempo que algunas partes no se revisan, así que puede que algunos enlaces estén desactualizados.
 items:
-  Chat Rooms:
-    title: Salas de chat
+  discord:
+    description: |
+      Hay dos servidores de Discord de ETC de uso general, ambos activos. Se enumeran en el orden en que se crearon, sin preferencia alguna; únete al que prefieras, o a los dos.
     items:
-      chat Discord:
-        name: Discordia (Comunidad, Global)
-      chat Discord Coop:
-        name: Discordia (ETC Coop)
+      discordClassic:
+        name: Discord de Ethereum Classic
+        description: 'El servidor original de la comunidad, en funcionamiento desde 2016, y sede de muchas de las anteriores llamadas de desarrolladores y llamadas comunitarias.'
+      discordCommunity:
+        name: Discord de la Comunidad de Ethereum Classic
+        description: 'Un servidor más reciente, lanzado en noviembre de 2025, con una moderación más estricta y con verificación automática, protección antispam e integraciones de anuncios. Consulta el [artículo del anuncio](/blog/2025-11-05-discord-migration) para más contexto.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'El grupo de [ETC Grants DAO](https://etcgrantsdao.io), que financia proyectos construidos sobre Ethereum Classic. Es uno de los chats de ETC con más movimiento, con muchos usuarios activos que comentan el día a día del ecosistema.'
+      telegramEnglish:
+        name: Ethereum Classic (inglés)
+        description: El veterano grupo en inglés para conversar sobre ETC en general.
+  twitter:
+    description: |
+      Las dos cuentas principales de la comunidad funcionan con [twitter-together](https://github.com/twitter-together/action): los tuits se proponen como pull requests en el repositorio de cada cuenta, se revisan de forma abierta y se publican automáticamente al fusionarse. La forma más sencilla de proponer uno es la [app de contribuciones de ETC](https://etc.contributions.app), que crea el pull request por ti, con o sin cuenta de GitHub. También se recogen ideas de los tuits con la etiqueta `#ETCtweets`, que se comentan en el hilo `#ETCtweets` de Discord.
+    items:
+      twitterEthClassic:
+        description: 'La más seguida de las dos cuentas, con unas normas editoriales que la mantienen formal, neutral y sin memes. Los tuits se proponen en [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Una cuenta menos formal, en la que se permiten memes y publicaciones más ligeras junto a las novedades de la red y del desarrollo. Los tuits se proponen en [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'El subreddit de Ethereum Classic, para debates más extensos, preguntas y para compartir noticias y enlaces de todo el ecosistema.'
+  Chat Rooms:
+    title: Otras salas de chat
+    items:
       chat Facebook English:
         name: Facebook (inglés)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Grupos de Telegramas
+    title: Grupos regionales de Telegram
     items:
-      telegram English:
-        name: Inglés
       telegram Español:
         name: English
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Foros
+    title: Otros foros
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -73,16 +95,12 @@ items:
       media Explore The Chain:
         name: Explorar la cadena
       media Let's Talk ETC!:
-        name: '¡Hablemos de ETC!'
+        name: ¡Hablemos de ETC!
   Twitter Accounts:
-    title: Cuentas de Twitter
+    title: Cuentas regionales de Twitter
     items:
       twitter China:
         name: China
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: English
       twitter France:

--- a/i18n/community/channels/index.es.yaml
+++ b/i18n/community/channels/index.es.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord de Ethereum Classic
-        description: 'El servidor original de la comunidad, en funcionamiento desde 2016, y sede de muchas de las anteriores llamadas de desarrolladores y llamadas comunitarias.'
+        description: 'El servidor original de la comunidad, en funcionamiento desde 2016, con una moderación ligera, y sede de muchas de las anteriores llamadas de desarrolladores y llamadas comunitarias.'
       discordCommunity:
         name: Discord de la Comunidad de Ethereum Classic
-        description: 'Un servidor más reciente, lanzado en noviembre de 2025, con una moderación más estricta y con verificación automática, protección antispam e integraciones de anuncios. Consulta el [artículo del anuncio](/blog/2025-11-05-discord-migration) para más contexto.'
+        description: 'Un servidor más reciente, lanzado en noviembre de 2025, con una moderación estricta y con verificación automática, protección antispam e integraciones de anuncios. Consulta el [artículo del anuncio](/blog/2025-11-05-discord-migration) para más contexto.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'El grupo de [ETC Grants DAO](https://etcgrantsdao.io), que financia proyectos construidos sobre Ethereum Classic. Es uno de los chats de ETC con más movimiento, con muchos usuarios activos que comentan el día a día del ecosistema.'
       telegramEnglish:
         name: Ethereum Classic (inglés)
         description: El veterano grupo en inglés para conversar sobre ETC en general.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'El grupo de [ETC Grants DAO](https://etcgrantsdao.io), que financia proyectos construidos sobre Ethereum Classic.'
   twitter:
     description: |
-      Las dos cuentas principales de la comunidad funcionan con [twitter-together](https://github.com/twitter-together/action): los tuits se proponen como pull requests en el repositorio de cada cuenta, se revisan de forma abierta y se publican automáticamente al fusionarse. La forma más sencilla de proponer uno es la [app de contribuciones de ETC](https://etc.contributions.app), que crea el pull request por ti, con o sin cuenta de GitHub. También se recogen ideas de los tuits con la etiqueta `#ETCtweets`, que se comentan en el hilo `#ETCtweets` de Discord.
+      Las dos cuentas gestionadas por la comunidad usan [twitter-together](https://github.com/twitter-together/action): los tuits se proponen como pull requests en el repositorio de cada cuenta, se revisan de forma abierta y se publican automáticamente al fusionarse. La forma más sencilla de proponer uno es la [app de contribuciones de ETC](https://etc.contributions.app), que crea el pull request por ti, con o sin cuenta de GitHub. También se recogen ideas de los tuits con la etiqueta `#ETCtweets`, que se comentan en el hilo `#ETCtweets` de Discord.
     items:
       twitterEthClassic:
         description: 'La más seguida de las dos cuentas, con unas normas editoriales que la mantienen formal, neutral y sin memes. Los tuits se proponen en [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.fr.yaml
+++ b/i18n/community/channels/index.fr.yaml
@@ -1,17 +1,43 @@
 title: Canaux sociaux
-seo: Une collection de salons de discussion Ethereum Classic, de comptes Twitter, de groupes de discussion, de forums, de podcasts, de référentiels et de sites Web régionaux.
+seo: 'Une collection de salons de discussion Ethereum Classic, de comptes Twitter, de groupes de discussion, de forums, de podcasts, de référentiels et de sites Web régionaux.'
 description: |
-  Voici une liste non exhaustive des groupes et canaux de discussion actifs sur Ethereum Classic.
+  Ethereum Classic n'a pas d'organisation centrale et n'a donc pas de réseaux sociaux « officiels » : chaque canal listé ici est géré de façon indépendante par des membres de la communauté.
 
-  La communauté ETC se trouve principalement sur [Discord](https://ethereumclassic.org/discord).
+  Les sections Discord, Telegram, Twitter et Reddit regroupent les canaux liés dans le pied de page de ce site. Le reste est un annuaire non exhaustif de groupes régionaux ou thématiques ; certaines parties n'ont pas été vérifiées depuis un moment, donc quelques liens peuvent être obsolètes.
 items:
-  Chat Rooms:
-    title: Salons de Discussion
+  discord:
+    description: |
+      Il existe deux serveurs Discord ETC généralistes, tous deux actifs. Ils sont présentés dans leur ordre de création, sans préférence ; rejoignez celui qui vous convient, ou les deux.
     items:
-      chat Discord:
-        name: Discord (Communauté, Global)
-      chat Discord Coop:
-        name: Discord (ETC Coop)
+      discordClassic:
+        name: Discord Ethereum Classic
+        description: 'Le serveur communautaire d''origine, en service depuis 2016, qui a accueilli une grande partie des anciens appels des core devs et des appels communautaires.'
+      discordCommunity:
+        name: Discord de la communauté Ethereum Classic
+        description: 'Un serveur plus récent, lancé en novembre 2025, à la modération plus stricte, doté d''une vérification automatique, d''une protection anti-spam et d''intégrations d''annonces. Voir l''[article d''annonce](/blog/2025-11-05-discord-migration) pour le contexte.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Le groupe d''[ETC Grants DAO](https://etcgrantsdao.io), qui finance des projets développés sur Ethereum Classic. C''est l''un des salons ETC les plus animés, avec de nombreux utilisateurs actifs qui échangent au quotidien sur l''écosystème.'
+      telegramEnglish:
+        name: Ethereum Classic (anglais)
+        description: Le groupe anglophone historique pour discuter d'ETC en général.
+  twitter:
+    description: |
+      Les deux comptes principaux de la communauté fonctionnent avec [twitter-together](https://github.com/twitter-together/action) : les tweets sont proposés sous forme de pull requests dans le dépôt du compte, relus publiquement, puis publiés automatiquement une fois fusionnés. Le plus simple pour en proposer un est l'[application de contributions ETC](https://etc.contributions.app), qui soumet la pull request à votre place, avec ou sans compte GitHub. Des idées sont aussi reprises des tweets marqués `#ETCtweets`, qui sont discutés dans le fil `#ETCtweets` sur Discord.
+    items:
+      twitterEthClassic:
+        description: 'Le plus suivi des deux comptes, avec une ligne éditoriale qui le garde formel, neutre et sans mèmes. Les tweets sont proposés dans [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Un compte moins formel, où les mèmes et les publications plus légères sont admis, aux côtés des actualités du réseau et du développement. Les tweets sont proposés dans [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Le subreddit Ethereum Classic, utilisé pour les discussions de fond, les questions et le partage d''actualités et de liens de tout l''écosystème.'
+  Chat Rooms:
+    title: Autres salons de discussion
+    items:
       chat Facebook English:
         name: Facebook (anglais)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Groupes Telegram
+    title: Groupes Telegram régionaux
     items:
-      telegram English:
-        name: Anglais
       telegram Español:
         name: Espagnol
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: Chinois
   Forums:
-    title: Forums
+    title: Autres forums
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Let's Talk ETC!
   Twitter Accounts:
-    title: Comptes Twitter
+    title: Comptes Twitter régionaux
     items:
       twitter China:
         name: Chine
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Espagne
       twitter France:

--- a/i18n/community/channels/index.fr.yaml
+++ b/i18n/community/channels/index.fr.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord Ethereum Classic
-        description: 'Le serveur communautaire d''origine, en service depuis 2016, qui a accueilli une grande partie des anciens appels des core devs et des appels communautaires.'
+        description: 'Le serveur communautaire d''origine, en service depuis 2016, à la modération légère, qui a accueilli une grande partie des anciens appels des core devs et des appels communautaires.'
       discordCommunity:
         name: Discord de la communauté Ethereum Classic
-        description: 'Un serveur plus récent, lancé en novembre 2025, à la modération plus stricte, doté d''une vérification automatique, d''une protection anti-spam et d''intégrations d''annonces. Voir l''[article d''annonce](/blog/2025-11-05-discord-migration) pour le contexte.'
+        description: 'Un serveur plus récent, lancé en novembre 2025, à la modération stricte, doté d''une vérification automatique, d''une protection anti-spam et d''intégrations d''annonces. Voir l''[article d''annonce](/blog/2025-11-05-discord-migration) pour le contexte.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Le groupe d''[ETC Grants DAO](https://etcgrantsdao.io), qui finance des projets développés sur Ethereum Classic. C''est l''un des salons ETC les plus animés, avec de nombreux utilisateurs actifs qui échangent au quotidien sur l''écosystème.'
       telegramEnglish:
         name: Ethereum Classic (anglais)
         description: Le groupe anglophone historique pour discuter d'ETC en général.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Le groupe d''[ETC Grants DAO](https://etcgrantsdao.io), qui finance des projets développés sur Ethereum Classic.'
   twitter:
     description: |
-      Les deux comptes principaux de la communauté fonctionnent avec [twitter-together](https://github.com/twitter-together/action) : les tweets sont proposés sous forme de pull requests dans le dépôt du compte, relus publiquement, puis publiés automatiquement une fois fusionnés. Le plus simple pour en proposer un est l'[application de contributions ETC](https://etc.contributions.app), qui soumet la pull request à votre place, avec ou sans compte GitHub. Des idées sont aussi reprises des tweets marqués `#ETCtweets`, qui sont discutés dans le fil `#ETCtweets` sur Discord.
+      Les deux comptes gérés par la communauté utilisent [twitter-together](https://github.com/twitter-together/action) : les tweets sont proposés sous forme de pull requests dans le dépôt du compte, relus publiquement, puis publiés automatiquement une fois fusionnés. Le plus simple pour en proposer un est l'[application de contributions ETC](https://etc.contributions.app), qui soumet la pull request à votre place, avec ou sans compte GitHub. Des idées sont aussi reprises des tweets marqués `#ETCtweets`, qui sont discutés dans le fil `#ETCtweets` sur Discord.
     items:
       twitterEthClassic:
         description: 'Le plus suivi des deux comptes, avec une ligne éditoriale qui le garde formel, neutre et sans mèmes. Les tweets sont proposés dans [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.he.yaml
+++ b/i18n/community/channels/index.he.yaml
@@ -1,17 +1,43 @@
 title: ערוצים חברתיים
-seo: אוסף של חדרי צ'אט Ethereum Classic, חשבונות טוויטר, קבוצות דיון, פורומים, פודקאסטים, מאגרים ואתרי אינטרנט אזוריים.
+seo: 'אוסף של חדרי צ''אט Ethereum Classic, חשבונות טוויטר, קבוצות דיון, פורומים, פודקאסטים, מאגרים ואתרי אינטרנט אזוריים.'
 description: |
-  להלן רשימה לא ממצה של ערוצי דיון וקבוצות פעילים של Ethereum Classic.
+  ל-Ethereum Classic אין ארגון מרכזי, ולכן אין לו גם רשתות חברתיות "רשמיות"; כל ערוץ שמופיע כאן מנוהל באופן עצמאי על ידי חברי הקהילה.
 
-  מרכז הפעילות העיקרי בקהילת ETC כיום הוא ב [Discord](https://ethereumclassic.org/discord).
+  המקטעים Discord, Telegram, Twitter ו-Reddit מכסים את הערוצים המקושרים בכותרת התחתונה של אתר זה. שאר הרשימה היא מדריך חלקי לקבוצות אזוריות ונושאיות; חלקים ממנה לא נבדקו זמן מה, ולכן ייתכן שחלק מהקישורים אינם מעודכנים.
 items:
-  Chat Rooms:
-    title: חדרי צ'אט
+  discord:
+    description: |
+      קיימים שני שרתי Discord כלליים של ETC, ושניהם פעילים. הם מופיעים לפי סדר הקמתם, ללא העדפה; אפשר להצטרף לזה שמתאים לכם, או לשניהם.
     items:
-      chat Discord:
-        name: דיסקורד (קהילה, גלובלי)
-      chat Discord Coop:
-        name: דיסקורד (ETC Coop)
+      discordClassic:
+        name: Discord של Ethereum Classic
+        description: 'שרת הקהילה המקורי, פועל מאז 2016, ובו התקיימו רבות משיחות מפתחי הליבה ומשיחות הקהילה בעבר.'
+      discordCommunity:
+        name: Discord של קהילת Ethereum Classic
+        description: 'שרת חדש יותר, שהושק בנובמבר 2025, עם ניהול קפדני יותר, אימות אוטומטי, הגנה מפני ספאם ושילובי הודעות. לרקע נוסף ראו את [פוסט ההכרזה](/blog/2025-11-05-discord-migration).'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'הקבוצה סביב [ETC Grants DAO](https://etcgrantsdao.io), שמממן פרויקטים הנבנים על Ethereum Classic. זו אחת מקבוצות הצ''אט הפעילות ביותר של ETC, עם משתמשים רבים שדנים במערכת האקולוגית מדי יום.'
+      telegramEnglish:
+        name: Ethereum Classic (אנגלית)
+        description: הקבוצה הוותיקה בשפה האנגלית לשיחה כללית על ETC.
+  twitter:
+    description: |
+      שני חשבונות הקהילה המרכזיים מנוהלים באמצעות [twitter-together](https://github.com/twitter-together/action): ציוצים מוצעים כבקשות משיכה במאגר של החשבון, נבדקים בגלוי ומתפרסמים אוטומטית לאחר המיזוג. הדרך הפשוטה ביותר להציע ציוץ היא [אפליקציית התרומות של ETC](https://etc.contributions.app), שמגישה עבורכם את בקשת המשיכה, עם חשבון GitHub או בלעדיו. רעיונות נאספים גם מציוצים המתויגים ב-`#ETCtweets`, ונדונים בשרשור `#ETCtweets` ב-Discord.
+    items:
+      twitterEthClassic:
+        description: 'החשבון בעל מספר העוקבים הגדול יותר מבין השניים, עם קווים מנחים ששומרים עליו רשמי, ניטרלי ונטול ממים. ציוצים מוצעים ב-[tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'חשבון פחות רשמי, שבו מותרים ממים ופוסטים קלילים לצד עדכוני רשת ופיתוח. ציוצים מוצעים ב-[tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'הסאב-רדיט של Ethereum Classic, המשמש לדיונים ארוכים, שאלות ושיתוף חדשות וקישורים מכל המערכת האקולוגית.'
+  Chat Rooms:
+    title: חדרי צ'אט נוספים
+    items:
       chat Facebook English:
         name: פייסבוק (אנגלית)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: קבוצות טלגרם
+    title: קבוצות Telegram אזוריות
     items:
-      telegram English:
-        name: אנגלית
       telegram Español:
         name: Español
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: פורומים
+    title: פורומים נוספים
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: בואו נדבר וכו'!
   Twitter Accounts:
-    title: חשבונות טוויטר
+    title: חשבונות Twitter אזוריים
     items:
       twitter China:
         name: חרסינה
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Español
       twitter France:

--- a/i18n/community/channels/index.he.yaml
+++ b/i18n/community/channels/index.he.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord של Ethereum Classic
-        description: 'שרת הקהילה המקורי, פועל מאז 2016, ובו התקיימו רבות משיחות מפתחי הליבה ומשיחות הקהילה בעבר.'
+        description: 'שרת הקהילה המקורי, פועל מאז 2016, עם ניהול מקל, ובו התקיימו רבות משיחות מפתחי הליבה ומשיחות הקהילה בעבר.'
       discordCommunity:
         name: Discord של קהילת Ethereum Classic
-        description: 'שרת חדש יותר, שהושק בנובמבר 2025, עם ניהול קפדני יותר, אימות אוטומטי, הגנה מפני ספאם ושילובי הודעות. לרקע נוסף ראו את [פוסט ההכרזה](/blog/2025-11-05-discord-migration).'
+        description: 'שרת חדש יותר, שהושק בנובמבר 2025, עם ניהול קפדני, אימות אוטומטי, הגנה מפני ספאם ושילובי הודעות. לרקע נוסף ראו את [פוסט ההכרזה](/blog/2025-11-05-discord-migration).'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'הקבוצה סביב [ETC Grants DAO](https://etcgrantsdao.io), שמממן פרויקטים הנבנים על Ethereum Classic. זו אחת מקבוצות הצ''אט הפעילות ביותר של ETC, עם משתמשים רבים שדנים במערכת האקולוגית מדי יום.'
       telegramEnglish:
         name: Ethereum Classic (אנגלית)
         description: הקבוצה הוותיקה בשפה האנגלית לשיחה כללית על ETC.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'הקבוצה סביב [ETC Grants DAO](https://etcgrantsdao.io), שמממן פרויקטים הנבנים על Ethereum Classic.'
   twitter:
     description: |
-      שני חשבונות הקהילה המרכזיים מנוהלים באמצעות [twitter-together](https://github.com/twitter-together/action): ציוצים מוצעים כבקשות משיכה במאגר של החשבון, נבדקים בגלוי ומתפרסמים אוטומטית לאחר המיזוג. הדרך הפשוטה ביותר להציע ציוץ היא [אפליקציית התרומות של ETC](https://etc.contributions.app), שמגישה עבורכם את בקשת המשיכה, עם חשבון GitHub או בלעדיו. רעיונות נאספים גם מציוצים המתויגים ב-`#ETCtweets`, ונדונים בשרשור `#ETCtweets` ב-Discord.
+      שני החשבונות שמנהלת הקהילה משתמשים ב-[twitter-together](https://github.com/twitter-together/action): ציוצים מוצעים כבקשות משיכה במאגר של החשבון, נבדקים בגלוי ומתפרסמים אוטומטית לאחר המיזוג. הדרך הפשוטה ביותר להציע ציוץ היא [אפליקציית התרומות של ETC](https://etc.contributions.app), שמגישה עבורכם את בקשת המשיכה, עם חשבון GitHub או בלעדיו. רעיונות נאספים גם מציוצים המתויגים ב-`#ETCtweets`, ונדונים בשרשור `#ETCtweets` ב-Discord.
     items:
       twitterEthClassic:
         description: 'החשבון בעל מספר העוקבים הגדול יותר מבין השניים, עם קווים מנחים ששומרים עליו רשמי, ניטרלי ונטול ממים. ציוצים מוצעים ב-[tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.hi.yaml
+++ b/i18n/community/channels/index.hi.yaml
@@ -1,17 +1,43 @@
 title: सामाजिक चैनल
-seo: एथेरियम क्लासिक चैट रूम, ट्विटर अकाउंट, चर्चा समूह, फ़ोरम, पॉडकास्ट, रिपॉजिटरी और क्षेत्रीय वेबसाइटों का संग्रह।
+seo: 'एथेरियम क्लासिक चैट रूम, ट्विटर अकाउंट, चर्चा समूह, फ़ोरम, पॉडकास्ट, रिपॉजिटरी और क्षेत्रीय वेबसाइटों का संग्रह।'
 description: |
-  निम्नलिखित सक्रिय एथेरियम क्लासिक चर्चा चैनलों और समूहों की एक गैर-विस्तृत सूची है।
+  Ethereum Classic का कोई केंद्रीय संगठन नहीं है, इसलिए कोई "आधिकारिक" सोशल मीडिया भी नहीं है; यहाँ सूचीबद्ध हर चैनल समुदाय के सदस्य स्वतंत्र रूप से चलाते हैं।
 
-  वर्तमान में ETC समुदाय के भीतर गतिविधि का मुख्य केंद्र [Discord](https://ethereumclassic.org/discord) पर है।
+  Discord, Telegram, Twitter और Reddit वाले हिस्से उन चैनलों को कवर करते हैं जिनके लिंक इस वेबसाइट के फ़ुटर में हैं। बाकी हिस्सा क्षेत्रीय और विषय-विशेष समूहों की एक अधूरी सूची है; इसके कुछ हिस्सों की काफ़ी समय से जाँच नहीं हुई है, इसलिए कुछ लिंक पुराने हो सकते हैं।
 items:
-  Chat Rooms:
-    title: चैट रूम
+  discord:
+    description: |
+      ETC के दो सामान्य उद्देश्य वाले Discord सर्वर हैं, और दोनों सक्रिय हैं। इन्हें बनने के क्रम में, बिना किसी वरीयता के सूचीबद्ध किया गया है; आपको जो ठीक लगे उसमें, या दोनों में शामिल हों।
     items:
-      chat Discord:
-        name: कलह (समुदाय, वैश्विक)
-      chat Discord Coop:
-        name: कलह (ईटीसी कॉप)
+      discordClassic:
+        name: Ethereum Classic Discord
+        description: 'समुदाय का मूल सर्वर, जो 2016 से चल रहा है और जहाँ पहले की कई कोर डेवलपर कॉल और सामुदायिक कॉल हुई हैं।'
+      discordCommunity:
+        name: Ethereum Classic कम्युनिटी Discord
+        description: 'नवंबर 2025 में शुरू हुआ नया सर्वर, जहाँ मॉडरेशन अधिक सख़्त है और स्वचालित सत्यापन, स्पैम-रोधी सुरक्षा तथा घोषणाओं के इंटीग्रेशन मौजूद हैं। पृष्ठभूमि के लिए [घोषणा वाली पोस्ट](/blog/2025-11-05-discord-migration) देखें।'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: '[ETC Grants DAO](https://etcgrantsdao.io) से जुड़ा समूह, जो Ethereum Classic पर बन रही परियोजनाओं को अनुदान देता है। यह ETC के सबसे व्यस्त चैट समूहों में से एक है, जहाँ कई सक्रिय उपयोगकर्ता रोज़ाना पारिस्थितिकी तंत्र पर चर्चा करते हैं।'
+      telegramEnglish:
+        name: Ethereum Classic (अंग्रेज़ी)
+        description: ETC पर सामान्य बातचीत के लिए लंबे समय से चला आ रहा अंग्रेज़ी समूह।
+  twitter:
+    description: |
+      समुदाय के दोनों मुख्य खाते [twitter-together](https://github.com/twitter-together/action) से चलते हैं: ट्वीट खाते की रिपॉज़िटरी में पुल रिक्वेस्ट के रूप में प्रस्तावित होते हैं, खुले तौर पर उनकी समीक्षा होती है और मर्ज होते ही वे अपने आप पोस्ट हो जाते हैं। सबसे आसान तरीका [ETC कंट्रीब्यूशंस ऐप](https://etc.contributions.app) है, जो आपकी ओर से पुल रिक्वेस्ट भेज देता है, चाहे आपके पास GitHub खाता हो या न हो। `#ETCtweets` टैग वाले ट्वीट से भी विचार लिए जाते हैं, जिन पर Discord के `#ETCtweets` थ्रेड में चर्चा होती है।
+    items:
+      twitterEthClassic:
+        description: 'दोनों में से अधिक फ़ॉलो किया जाने वाला खाता, जिसके संपादकीय दिशानिर्देश इसे औपचारिक, तटस्थ और मीम-मुक्त रखते हैं। ट्वीट [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) में प्रस्तावित किए जाते हैं।'
+      twitterEtcNetwork:
+        description: 'कम औपचारिक खाता, जहाँ नेटवर्क और विकास से जुड़ी ख़बरों के साथ मीम और हल्की-फुल्की पोस्ट भी स्वीकार्य हैं। ट्वीट [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network) में प्रस्तावित किए जाते हैं।'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Ethereum Classic का सबरेडिट, जो लंबी चर्चाओं, सवालों और पूरे पारिस्थितिकी तंत्र की ख़बरें व लिंक साझा करने के लिए इस्तेमाल होता है।'
+  Chat Rooms:
+    title: अन्य चैट रूम
+    items:
       chat Facebook English:
         name: फेसबुक (अंग्रेज़ी)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: हाइपरलेगर बेसू
   Telegram Groups:
-    title: टेलीग्राम समूह
+    title: क्षेत्रीय Telegram समूह
     items:
-      telegram English:
-        name: अंग्रेज़ी
       telegram Español:
         name: स्पेनोलि
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: मैं
   Forums:
-    title: मंचों
+    title: अन्य फ़ोरम
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: बिटकॉइनटॉक
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: ईटीसी बात करते हैं!
   Twitter Accounts:
-    title: ट्विटर खाते
+    title: क्षेत्रीय Twitter खाते
     items:
       twitter China:
         name: चीन
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: स्पेनोलि
       twitter France:

--- a/i18n/community/channels/index.hi.yaml
+++ b/i18n/community/channels/index.hi.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Ethereum Classic Discord
-        description: 'समुदाय का मूल सर्वर, जो 2016 से चल रहा है और जहाँ पहले की कई कोर डेवलपर कॉल और सामुदायिक कॉल हुई हैं।'
+        description: 'समुदाय का मूल सर्वर, जो 2016 से चल रहा है, जहाँ मॉडरेशन हल्का है और जहाँ पहले की कई कोर डेवलपर कॉल और सामुदायिक कॉल हुई हैं।'
       discordCommunity:
         name: Ethereum Classic कम्युनिटी Discord
-        description: 'नवंबर 2025 में शुरू हुआ नया सर्वर, जहाँ मॉडरेशन अधिक सख़्त है और स्वचालित सत्यापन, स्पैम-रोधी सुरक्षा तथा घोषणाओं के इंटीग्रेशन मौजूद हैं। पृष्ठभूमि के लिए [घोषणा वाली पोस्ट](/blog/2025-11-05-discord-migration) देखें।'
+        description: 'नवंबर 2025 में शुरू हुआ नया सर्वर, जहाँ मॉडरेशन सख़्त है और स्वचालित सत्यापन, स्पैम-रोधी सुरक्षा तथा घोषणाओं के इंटीग्रेशन मौजूद हैं। पृष्ठभूमि के लिए [घोषणा वाली पोस्ट](/blog/2025-11-05-discord-migration) देखें।'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: '[ETC Grants DAO](https://etcgrantsdao.io) से जुड़ा समूह, जो Ethereum Classic पर बन रही परियोजनाओं को अनुदान देता है। यह ETC के सबसे व्यस्त चैट समूहों में से एक है, जहाँ कई सक्रिय उपयोगकर्ता रोज़ाना पारिस्थितिकी तंत्र पर चर्चा करते हैं।'
       telegramEnglish:
         name: Ethereum Classic (अंग्रेज़ी)
         description: ETC पर सामान्य बातचीत के लिए लंबे समय से चला आ रहा अंग्रेज़ी समूह।
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: '[ETC Grants DAO](https://etcgrantsdao.io) से जुड़ा समूह, जो Ethereum Classic पर बन रही परियोजनाओं को अनुदान देता है।'
   twitter:
     description: |
-      समुदाय के दोनों मुख्य खाते [twitter-together](https://github.com/twitter-together/action) से चलते हैं: ट्वीट खाते की रिपॉज़िटरी में पुल रिक्वेस्ट के रूप में प्रस्तावित होते हैं, खुले तौर पर उनकी समीक्षा होती है और मर्ज होते ही वे अपने आप पोस्ट हो जाते हैं। सबसे आसान तरीका [ETC कंट्रीब्यूशंस ऐप](https://etc.contributions.app) है, जो आपकी ओर से पुल रिक्वेस्ट भेज देता है, चाहे आपके पास GitHub खाता हो या न हो। `#ETCtweets` टैग वाले ट्वीट से भी विचार लिए जाते हैं, जिन पर Discord के `#ETCtweets` थ्रेड में चर्चा होती है।
+      समुदाय द्वारा चलाए जाने वाले दोनों खाते [twitter-together](https://github.com/twitter-together/action) का उपयोग करते हैं: ट्वीट खाते की रिपॉज़िटरी में पुल रिक्वेस्ट के रूप में प्रस्तावित होते हैं, खुले तौर पर उनकी समीक्षा होती है और मर्ज होते ही वे अपने आप पोस्ट हो जाते हैं। सबसे आसान तरीका [ETC कंट्रीब्यूशंस ऐप](https://etc.contributions.app) है, जो आपकी ओर से पुल रिक्वेस्ट भेज देता है, चाहे आपके पास GitHub खाता हो या न हो। `#ETCtweets` टैग वाले ट्वीट से भी विचार लिए जाते हैं, जिन पर Discord के `#ETCtweets` थ्रेड में चर्चा होती है।
     items:
       twitterEthClassic:
         description: 'दोनों में से अधिक फ़ॉलो किया जाने वाला खाता, जिसके संपादकीय दिशानिर्देश इसे औपचारिक, तटस्थ और मीम-मुक्त रखते हैं। ट्वीट [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) में प्रस्तावित किए जाते हैं।'

--- a/i18n/community/channels/index.hr.yaml
+++ b/i18n/community/channels/index.hr.yaml
@@ -1,17 +1,43 @@
 title: Društveni kanali
-seo: Zbirka Ethereum Classic chat soba, Twitter računa, grupa za raspravu, foruma, podcasta, spremišta i regionalnih web stranica.
+seo: 'Zbirka Ethereum Classic chat soba, Twitter računa, grupa za raspravu, foruma, podcasta, spremišta i regionalnih web stranica.'
 description: |
-  Slijedi neiscrpan popis aktivnih Ethereum Classic kanala za raspravu i grupa.
+  Ethereum Classic nema središnju organizaciju pa nema ni "službene" društvene mreže; svaki kanal naveden ovdje samostalno vode članovi zajednice.
 
-  Trenutno je glavno središte aktivnosti unutar ETC zajednice na [Discord](https://ethereumclassic.org/discord).
+  Odjeljci Discord, Telegram, Twitter i Reddit obuhvaćaju kanale povezane u podnožju ove stranice. Ostalo je necjelovit popis regionalnih i tematskih grupa; dijelovi tog popisa dugo nisu provjereni pa neke poveznice mogu biti zastarjele.
 items:
-  Chat Rooms:
-    title: Chat sobe
+  discord:
+    description: |
+      Postoje dva ETC Discord poslužitelja opće namjene, oba aktivna. Navedeni su redoslijedom nastanka, bez davanja prednosti; pridružite se onom koji vam odgovara, ili objema.
     items:
-      chat Discord:
-        name: Discord (zajednica, globalno)
-      chat Discord Coop:
-        name: Discord (ETC Coop)
+      discordClassic:
+        name: Ethereum Classic Discord
+        description: 'Izvorni poslužitelj zajednice, u radu od 2016., na kojem su održani mnogi raniji pozivi core razvojnih programera i pozivi zajednice.'
+      discordCommunity:
+        name: Discord zajednice Ethereum Classic
+        description: 'Noviji poslužitelj, pokrenut u studenom 2025., strože moderiran, s automatskom provjerom, zaštitom od neželjenih poruka i integracijama za objave. Pozadinu potražite u [objavi najave](/blog/2025-11-05-discord-migration).'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Grupa okupljena oko [ETC Grants DAO-a](https://etcgrantsdao.io), koji financira projekte na Ethereum Classicu. Jedan je od najživljih ETC razgovora, s mnogo aktivnih korisnika koji svakodnevno raspravljaju o ekosustavu.'
+      telegramEnglish:
+        name: Ethereum Classic (engleski)
+        description: Dugogodišnja grupa na engleskom jeziku za općenit razgovor o ETC-u.
+  twitter:
+    description: |
+      Dva glavna računa zajednice vode se pomoću [twitter-togethera](https://github.com/twitter-together/action): tweetovi se predlažu kao pull requestovi u repozitoriju računa, javno se pregledavaju i automatski objavljuju nakon spajanja. Najjednostavnije je predložiti ga putem [ETC-ove aplikacije za doprinose](https://etc.contributions.app), koja pull request otvara umjesto vas, sa ili bez GitHub računa. Ideje se preuzimaju i iz tweetova označenih s `#ETCtweets`, o kojima se raspravlja u niti `#ETCtweets` na Discordu.
+    items:
+      twitterEthClassic:
+        description: 'Praćeniji od dva računa, s uredničkim smjernicama koje ga drže formalnim, neutralnim i bez memeova. Tweetovi se predlažu u [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Manje formalan račun na kojem su uz vijesti o mreži i razvoju dopušteni memeovi i opušteniji sadržaj. Tweetovi se predlažu u [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Subreddit Ethereum Classica, za opširnije rasprave, pitanja te dijeljenje vijesti i poveznica iz cijelog ekosustava.'
+  Chat Rooms:
+    title: Ostale sobe za razgovor
+    items:
       chat Facebook English:
         name: Facebook (engleski)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Telegram grupe
+    title: Regionalne Telegram grupe
     items:
-      telegram English:
-        name: Engleski
       telegram Español:
         name: španjolski
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Forumi
+    title: Ostali forumi
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Razgovarajmo ITD!
   Twitter Accounts:
-    title: Twitter računi
+    title: Regionalni Twitter računi
     items:
       twitter China:
         name: Kina
-      twitter English 1:
-        name: "@ETC_Mreža"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: španjolski
       twitter France:

--- a/i18n/community/channels/index.hr.yaml
+++ b/i18n/community/channels/index.hr.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Ethereum Classic Discord
-        description: 'Izvorni poslužitelj zajednice, u radu od 2016., na kojem su održani mnogi raniji pozivi core razvojnih programera i pozivi zajednice.'
+        description: 'Izvorni poslužitelj zajednice, u radu od 2016., labavo moderiran, na kojem su održani mnogi raniji pozivi core razvojnih programera i pozivi zajednice.'
       discordCommunity:
         name: Discord zajednice Ethereum Classic
-        description: 'Noviji poslužitelj, pokrenut u studenom 2025., strože moderiran, s automatskom provjerom, zaštitom od neželjenih poruka i integracijama za objave. Pozadinu potražite u [objavi najave](/blog/2025-11-05-discord-migration).'
+        description: 'Noviji poslužitelj, pokrenut u studenom 2025., strogo moderiran, s automatskom provjerom, zaštitom od neželjenih poruka i integracijama za objave. Pozadinu potražite u [objavi najave](/blog/2025-11-05-discord-migration).'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Grupa okupljena oko [ETC Grants DAO-a](https://etcgrantsdao.io), koji financira projekte na Ethereum Classicu. Jedan je od najživljih ETC razgovora, s mnogo aktivnih korisnika koji svakodnevno raspravljaju o ekosustavu.'
       telegramEnglish:
         name: Ethereum Classic (engleski)
         description: Dugogodišnja grupa na engleskom jeziku za općenit razgovor o ETC-u.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Grupa okupljena oko [ETC Grants DAO-a](https://etcgrantsdao.io), koji financira projekte na Ethereum Classicu.'
   twitter:
     description: |
-      Dva glavna računa zajednice vode se pomoću [twitter-togethera](https://github.com/twitter-together/action): tweetovi se predlažu kao pull requestovi u repozitoriju računa, javno se pregledavaju i automatski objavljuju nakon spajanja. Najjednostavnije je predložiti ga putem [ETC-ove aplikacije za doprinose](https://etc.contributions.app), koja pull request otvara umjesto vas, sa ili bez GitHub računa. Ideje se preuzimaju i iz tweetova označenih s `#ETCtweets`, o kojima se raspravlja u niti `#ETCtweets` na Discordu.
+      Dva računa koja vodi zajednica koriste [twitter-together](https://github.com/twitter-together/action): tweetovi se predlažu kao pull requestovi u repozitoriju računa, javno se pregledavaju i automatski objavljuju nakon spajanja. Najjednostavnije je predložiti ga putem [ETC-ove aplikacije za doprinose](https://etc.contributions.app), koja pull request otvara umjesto vas, sa ili bez GitHub računa. Ideje se preuzimaju i iz tweetova označenih s `#ETCtweets`, o kojima se raspravlja u niti `#ETCtweets` na Discordu.
     items:
       twitterEthClassic:
         description: 'Praćeniji od dva računa, s uredničkim smjernicama koje ga drže formalnim, neutralnim i bez memeova. Tweetovi se predlažu u [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.it.yaml
+++ b/i18n/community/channels/index.it.yaml
@@ -1,17 +1,43 @@
 title: Canali sociali
-seo: Una raccolta di chat room di Ethereum Classic, account Twitter, gruppi di discussione, forum, podcast, repository e siti web regionali.
+seo: 'Una raccolta di chat room di Ethereum Classic, account Twitter, gruppi di discussione, forum, podcast, repository e siti web regionali.'
 description: |
-  Quello che segue è un elenco non esaustivo di canali e gruppi di discussione attivi su Ethereum Classic.
+  Ethereum Classic non ha un'organizzazione centrale e quindi non ha social media «ufficiali»: ogni canale elencato qui è gestito in modo indipendente da membri della comunità.
 
-  Il principale centro di attività della comunità ETC è attualmente [Discord](https://ethereumclassic.org/discord).
+  Le sezioni Discord, Telegram, Twitter e Reddit raccolgono i canali collegati nel piè di pagina di questo sito. Il resto è un elenco non esaustivo di gruppi regionali e tematici; alcune parti non vengono verificate da tempo, quindi qualche link potrebbe non essere più valido.
 items:
-  Chat Rooms:
-    title: Stanze di chat
+  discord:
+    description: |
+      Ci sono due server Discord ETC generalisti, entrambi attivi. Sono elencati nell'ordine in cui sono stati creati, senza preferenze: unisciti a quello che preferisci, o a entrambi.
     items:
-      chat Discord:
-        name: Discordia (Comunità, Globale)
-      chat Discord Coop:
-        name: Discordia (ETC Coop)
+      discordClassic:
+        name: Discord di Ethereum Classic
+        description: 'Il server originale della comunità, attivo dal 2016, sede di molte delle passate call dei core dev e delle community call.'
+      discordCommunity:
+        name: Discord della Comunità di Ethereum Classic
+        description: 'Un server più recente, lanciato a novembre 2025, con una moderazione più rigida e con verifica automatica, protezione anti-spam e integrazioni per gli annunci. Vedi il [post di annuncio](/blog/2025-11-05-discord-migration) per il contesto.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Il gruppo di [ETC Grants DAO](https://etcgrantsdao.io), che finanzia progetti costruiti su Ethereum Classic. È una delle chat ETC più vivaci, con molti utenti attivi che discutono ogni giorno dell''ecosistema.'
+      telegramEnglish:
+        name: Ethereum Classic (inglese)
+        description: Lo storico gruppo in lingua inglese per parlare di ETC in generale.
+  twitter:
+    description: |
+      I due account principali della comunità funzionano con [twitter-together](https://github.com/twitter-together/action): i tweet vengono proposti come pull request nel repository dell'account, revisionati in modo trasparente e pubblicati automaticamente una volta uniti. Il modo più semplice per proporne uno è l'[app contributi di ETC](https://etc.contributions.app), che apre la pull request al posto tuo, con o senza un account GitHub. Le idee arrivano anche dai tweet con l'hashtag `#ETCtweets`, discussi nel thread `#ETCtweets` su Discord.
+    items:
+      twitterEthClassic:
+        description: 'Il più seguito dei due account, con linee editoriali che lo mantengono formale, neutrale e senza meme. I tweet si propongono in [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Un account meno formale, dove sono ammessi meme e post più leggeri accanto agli aggiornamenti su rete e sviluppo. I tweet si propongono in [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Il subreddit di Ethereum Classic, usato per discussioni più approfondite, domande e per condividere notizie e link da tutto l''ecosistema.'
+  Chat Rooms:
+    title: Altre chat room
+    items:
       chat Facebook English:
         name: Facebook (inglese)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Gruppi Telegram
+    title: Gruppi Telegram regionali
     items:
-      telegram English:
-        name: Inglese
       telegram Español:
         name: Español
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Forum
+    title: Altri forum
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Parliamo di ETC!
   Twitter Accounts:
-    title: Account Twitter
+    title: Account Twitter regionali
     items:
       twitter China:
         name: Cina
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Español
       twitter France:

--- a/i18n/community/channels/index.it.yaml
+++ b/i18n/community/channels/index.it.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord di Ethereum Classic
-        description: 'Il server originale della comunità, attivo dal 2016, sede di molte delle passate call dei core dev e delle community call.'
+        description: 'Il server originale della comunità, attivo dal 2016, con una moderazione leggera, sede di molte delle passate call dei core dev e delle community call.'
       discordCommunity:
         name: Discord della Comunità di Ethereum Classic
-        description: 'Un server più recente, lanciato a novembre 2025, con una moderazione più rigida e con verifica automatica, protezione anti-spam e integrazioni per gli annunci. Vedi il [post di annuncio](/blog/2025-11-05-discord-migration) per il contesto.'
+        description: 'Un server più recente, lanciato a novembre 2025, con una moderazione rigida e con verifica automatica, protezione anti-spam e integrazioni per gli annunci. Vedi il [post di annuncio](/blog/2025-11-05-discord-migration) per il contesto.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Il gruppo di [ETC Grants DAO](https://etcgrantsdao.io), che finanzia progetti costruiti su Ethereum Classic. È una delle chat ETC più vivaci, con molti utenti attivi che discutono ogni giorno dell''ecosistema.'
       telegramEnglish:
         name: Ethereum Classic (inglese)
         description: Lo storico gruppo in lingua inglese per parlare di ETC in generale.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Il gruppo di [ETC Grants DAO](https://etcgrantsdao.io), che finanzia progetti costruiti su Ethereum Classic.'
   twitter:
     description: |
-      I due account principali della comunità funzionano con [twitter-together](https://github.com/twitter-together/action): i tweet vengono proposti come pull request nel repository dell'account, revisionati in modo trasparente e pubblicati automaticamente una volta uniti. Il modo più semplice per proporne uno è l'[app contributi di ETC](https://etc.contributions.app), che apre la pull request al posto tuo, con o senza un account GitHub. Le idee arrivano anche dai tweet con l'hashtag `#ETCtweets`, discussi nel thread `#ETCtweets` su Discord.
+      I due account gestiti dalla comunità usano [twitter-together](https://github.com/twitter-together/action): i tweet vengono proposti come pull request nel repository dell'account, revisionati in modo trasparente e pubblicati automaticamente una volta uniti. Il modo più semplice per proporne uno è l'[app contributi di ETC](https://etc.contributions.app), che apre la pull request al posto tuo, con o senza un account GitHub. Le idee arrivano anche dai tweet con l'hashtag `#ETCtweets`, discussi nel thread `#ETCtweets` su Discord.
     items:
       twitterEthClassic:
         description: 'Il più seguito dei due account, con linee editoriali che lo mantengono formale, neutrale e senza meme. I tweet si propongono in [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.ja.yaml
+++ b/i18n/community/channels/index.ja.yaml
@@ -1,17 +1,43 @@
 title: ソーシャルチャネル
 seo: Ethereum Classicのチャットルーム、Twitterアカウント、ディスカッショングループ、フォーラム、ポッドキャスト、リポジトリ、地域のウェブサイトを集めたサイト。
 description: |
-  以下は、アクティブなEthereum Classicのディスカッションチャンネルとグループの非網羅的なリストです。
+  Ethereum Classic には中心となる組織がなく、したがって「公式」のソーシャルメディアもありません。ここに挙げているチャンネルは、いずれもコミュニティのメンバーが独立して運営しています。
 
-  現在、ETCコミュニティ内の活動の主な中心は、 [Discord](https://ethereumclassic.org/discord) にあります。
+  Discord、Telegram、Twitter、Reddit の各セクションは、このサイトのフッターからリンクされているチャンネルをまとめたものです。それ以降は地域別・話題別のグループを網羅的ではない形で一覧にしたもので、しばらく確認されていない部分もあるため、古くなったリンクが含まれている可能性があります。
 items:
-  Chat Rooms:
-    title: チャットルーム
+  discord:
+    description: |
+      一般的な用途の ETC の Discord サーバーは 2 つあり、どちらも稼働しています。優劣をつけず、作成された順に並べています。好きな方に、あるいは両方に参加してください。
     items:
-      chat Discord:
-        name: Discord (コミュニティ、グローバル)
-      chat Discord Coop:
-        name: Discord(ETC生協)
+      discordClassic:
+        name: Ethereum Classic Discord
+        description: 2016 年から続く最初のコミュニティサーバーで、過去のコア開発者コールやコミュニティコールの多くがここで行われてきました。
+      discordCommunity:
+        name: Ethereum Classic コミュニティ Discord
+        description: '2025 年 11 月に開設された新しいサーバーで、モデレーションがより厳格で、自動認証、スパム対策、アナウンス連携を備えています。経緯は[お知らせの記事](/blog/2025-11-05-discord-migration)をご覧ください。'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Ethereum Classic 上のプロジェクトに助成を行う [ETC Grants DAO](https://etcgrantsdao.io) を中心としたグループです。ETC のチャットのなかでもとくに活発で、多くの利用者がエコシステムについて日々やり取りしています。'
+      telegramEnglish:
+        name: Ethereum Classic（英語）
+        description: ETC 全般について話す、長く続いている英語のグループです。
+  twitter:
+    description: |
+      主要な 2 つのコミュニティアカウントは [twitter-together](https://github.com/twitter-together/action) で運用されています。ツイートは各アカウントのリポジトリへのプルリクエストとして提案され、公開の場でレビューされ、マージされると自動的に投稿されます。もっとも簡単なのは [ETC コントリビューションアプリ](https://etc.contributions.app) を使う方法で、GitHub アカウントの有無にかかわらず、プルリクエストを代わりに作成してくれます。`#ETCtweets` を付けたツイートからも案が集められ、Discord の `#ETCtweets` スレッドで検討されます。
+    items:
+      twitterEthClassic:
+        description: '2 つのうちフォロワーが多い方のアカウントで、編集方針により、フォーマルで中立、ミームを扱わない内容に保たれています。ツイートは [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) で提案します。'
+      twitterEtcNetwork:
+        description: 'より砕けたアカウントで、ネットワークや開発の情報に加えて、ミームや軽い投稿も認められています。ツイートは [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network) で提案します。'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: Ethereum Classic の subreddit で、じっくりした議論や質問、エコシステム全体のニュースやリンクの共有に使われています。
+  Chat Rooms:
+    title: その他のチャットルーム
+    items:
       chat Facebook English:
         name: フェイスブック(英語)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: ハイパーレッジャー・ベスー
   Telegram Groups:
-    title: テレグラムグループ
+    title: 地域別 Telegram グループ
     items:
-      telegram English:
-        name: イングリッシュ
       telegram Español:
         name: スペイン語
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: フォーラム
+    title: その他のフォーラム
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: ビットコイントーク
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: レッツトークETC!
   Twitter Accounts:
-    title: Twitterアカウント
+    title: 地域別 Twitter アカウント
     items:
       twitter China:
         name: 中国
-      twitter English 1:
-        name: "ETC_Network"
-      twitter English 2:
-        name: "eth_classic"
       twitter Español:
         name: スペイン語
       twitter France:

--- a/i18n/community/channels/index.ja.yaml
+++ b/i18n/community/channels/index.ja.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Ethereum Classic Discord
-        description: 2016 年から続く最初のコミュニティサーバーで、過去のコア開発者コールやコミュニティコールの多くがここで行われてきました。
+        description: 2016 年から続く最初のコミュニティサーバーで、モデレーションは緩やかです。過去のコア開発者コールやコミュニティコールの多くがここで行われてきました。
       discordCommunity:
         name: Ethereum Classic コミュニティ Discord
-        description: '2025 年 11 月に開設された新しいサーバーで、モデレーションがより厳格で、自動認証、スパム対策、アナウンス連携を備えています。経緯は[お知らせの記事](/blog/2025-11-05-discord-migration)をご覧ください。'
+        description: '2025 年 11 月に開設された新しいサーバーで、モデレーションが厳格で、自動認証、スパム対策、アナウンス連携を備えています。経緯は[お知らせの記事](/blog/2025-11-05-discord-migration)をご覧ください。'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Ethereum Classic 上のプロジェクトに助成を行う [ETC Grants DAO](https://etcgrantsdao.io) を中心としたグループです。ETC のチャットのなかでもとくに活発で、多くの利用者がエコシステムについて日々やり取りしています。'
       telegramEnglish:
         name: Ethereum Classic（英語）
         description: ETC 全般について話す、長く続いている英語のグループです。
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Ethereum Classic 上のプロジェクトに助成を行う [ETC Grants DAO](https://etcgrantsdao.io) を中心としたグループです。'
   twitter:
     description: |
-      主要な 2 つのコミュニティアカウントは [twitter-together](https://github.com/twitter-together/action) で運用されています。ツイートは各アカウントのリポジトリへのプルリクエストとして提案され、公開の場でレビューされ、マージされると自動的に投稿されます。もっとも簡単なのは [ETC コントリビューションアプリ](https://etc.contributions.app) を使う方法で、GitHub アカウントの有無にかかわらず、プルリクエストを代わりに作成してくれます。`#ETCtweets` を付けたツイートからも案が集められ、Discord の `#ETCtweets` スレッドで検討されます。
+      コミュニティが運営する 2 つのアカウントは [twitter-together](https://github.com/twitter-together/action) を利用しています。ツイートは各アカウントのリポジトリへのプルリクエストとして提案され、公開の場でレビューされ、マージされると自動的に投稿されます。もっとも簡単なのは [ETC コントリビューションアプリ](https://etc.contributions.app) を使う方法で、GitHub アカウントの有無にかかわらず、プルリクエストを代わりに作成してくれます。`#ETCtweets` を付けたツイートからも案が集められ、Discord の `#ETCtweets` スレッドで検討されます。
     items:
       twitterEthClassic:
         description: '2 つのうちフォロワーが多い方のアカウントで、編集方針により、フォーマルで中立、ミームを扱わない内容に保たれています。ツイートは [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) で提案します。'

--- a/i18n/community/channels/index.ko.yaml
+++ b/i18n/community/channels/index.ko.yaml
@@ -1,17 +1,43 @@
 title: 소셜 채널
-seo: Ethereum Classic 대화방, Twitter 계정, 토론 그룹, 포럼, 팟캐스트, 저장소 및 지역 웹사이트 모음.
+seo: 'Ethereum Classic 대화방, Twitter 계정, 토론 그룹, 포럼, 팟캐스트, 저장소 및 지역 웹사이트 모음.'
 description: |
-  다음은 활성 Ethereum Classic 토론 채널 및 그룹의 전체 목록입니다.
+  Ethereum Classic에는 중앙 조직이 없으며, 따라서 "공식" 소셜 미디어도 없습니다. 여기에 나열된 채널은 모두 커뮤니티 구성원이 각자 독립적으로 운영합니다.
 
-  현재 ETC 커뮤니티 내 주요 활동 허브는 [Discord](https://ethereumclassic.org/discord)입니다.
+  Discord, Telegram, Twitter, Reddit 항목은 이 웹사이트 하단에 연결된 채널을 다룹니다. 그 아래는 지역별·주제별 그룹을 모아 둔 목록으로, 전부를 담고 있지는 않습니다. 한동안 점검하지 않은 부분이 있어 오래된 링크가 남아 있을 수 있습니다.
 items:
-  Chat Rooms:
-    title: 대화방
+  discord:
+    description: |
+      일반적인 용도의 ETC Discord 서버는 두 곳이며, 둘 다 활발히 운영되고 있습니다. 우열을 두지 않고 만들어진 순서대로 나열했습니다. 마음에 드는 곳에, 또는 두 곳 모두에 참여하세요.
     items:
-      chat Discord:
-        name: Discord(커뮤니티, 글로벌)
-      chat Discord Coop:
-        name: 디스코드(ETC Coop)
+      discordClassic:
+        name: Ethereum Classic Discord
+        description: '2016년부터 운영된 최초의 커뮤니티 서버로, 과거의 코어 개발자 콜과 커뮤니티 콜이 대부분 이곳에서 열렸습니다.'
+      discordCommunity:
+        name: Ethereum Classic 커뮤니티 Discord
+        description: '2025년 11월에 시작된 새로운 서버로, 더 엄격하게 관리되며 자동 인증, 스팸 차단, 공지 연동 기능을 갖추고 있습니다. 자세한 배경은 [공지 게시물](/blog/2025-11-05-discord-migration)을 참고하세요.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Ethereum Classic 위에서 개발되는 프로젝트를 지원하는 [ETC Grants DAO](https://etcgrantsdao.io) 관련 그룹입니다. 활동적인 사용자가 많아 생태계 이야기가 매일 오가는, ETC에서 가장 활발한 채팅방 중 하나입니다.'
+      telegramEnglish:
+        name: Ethereum Classic(영어)
+        description: 'ETC 전반을 이야기하는, 오랫동안 이어져 온 영어 그룹입니다.'
+  twitter:
+    description: |
+      두 개의 주요 커뮤니티 계정은 [twitter-together](https://github.com/twitter-together/action)로 운영됩니다. 트윗은 계정 저장소에 풀 리퀘스트로 제안되어 공개적으로 검토된 뒤, 병합되면 자동으로 게시됩니다. 가장 간단한 방법은 [ETC 기여 앱](https://etc.contributions.app)을 이용하는 것으로, GitHub 계정이 없어도 대신 풀 리퀘스트를 만들어 줍니다. `#ETCtweets` 태그가 달린 트윗에서도 아이디어를 모으며, 이는 Discord의 `#ETCtweets` 스레드에서 논의됩니다.
+    items:
+      twitterEthClassic:
+        description: '두 계정 중 팔로워가 더 많은 쪽으로, 편집 지침에 따라 격식 있고 중립적이며 밈을 다루지 않습니다. 트윗은 [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic)에서 제안합니다.'
+      twitterEtcNetwork:
+        description: '조금 더 가벼운 계정으로, 네트워크와 개발 소식과 함께 밈이나 가벼운 게시물도 허용됩니다. 트윗은 [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network)에서 제안합니다.'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Ethereum Classic의 서브레딧으로, 긴 호흡의 토론과 질문, 생태계 전반의 소식과 링크 공유에 쓰입니다.'
+  Chat Rooms:
+    title: 기타 채팅방
+    items:
       chat Facebook English:
         name: 페이스북(영어)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: 하이퍼레저 베수
   Telegram Groups:
-    title: 전보 그룹
+    title: 지역별 Telegram 그룹
     items:
-      telegram English:
-        name: 영어
       telegram Español:
         name: 스페인어
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 중문
   Forums:
-    title: 포럼
+    title: 기타 포럼
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: 비트코인톡
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Let's Talk ETC!
   Twitter Accounts:
-    title: 트위터 계정
+    title: 지역별 Twitter 계정
     items:
       twitter China:
         name: 중국
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: 스페인어
       twitter France:

--- a/i18n/community/channels/index.ko.yaml
+++ b/i18n/community/channels/index.ko.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Ethereum Classic Discord
-        description: '2016년부터 운영된 최초의 커뮤니티 서버로, 과거의 코어 개발자 콜과 커뮤니티 콜이 대부분 이곳에서 열렸습니다.'
+        description: '2016년부터 운영된 최초의 커뮤니티 서버로, 느슨하게 관리되며 과거의 코어 개발자 콜과 커뮤니티 콜이 대부분 이곳에서 열렸습니다.'
       discordCommunity:
         name: Ethereum Classic 커뮤니티 Discord
-        description: '2025년 11월에 시작된 새로운 서버로, 더 엄격하게 관리되며 자동 인증, 스팸 차단, 공지 연동 기능을 갖추고 있습니다. 자세한 배경은 [공지 게시물](/blog/2025-11-05-discord-migration)을 참고하세요.'
+        description: '2025년 11월에 시작된 새로운 서버로, 엄격하게 관리되며 자동 인증, 스팸 차단, 공지 연동 기능을 갖추고 있습니다. 자세한 배경은 [공지 게시물](/blog/2025-11-05-discord-migration)을 참고하세요.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Ethereum Classic 위에서 개발되는 프로젝트를 지원하는 [ETC Grants DAO](https://etcgrantsdao.io) 관련 그룹입니다. 활동적인 사용자가 많아 생태계 이야기가 매일 오가는, ETC에서 가장 활발한 채팅방 중 하나입니다.'
       telegramEnglish:
         name: Ethereum Classic(영어)
         description: 'ETC 전반을 이야기하는, 오랫동안 이어져 온 영어 그룹입니다.'
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Ethereum Classic 위에서 개발되는 프로젝트를 지원하는 [ETC Grants DAO](https://etcgrantsdao.io) 관련 그룹입니다.'
   twitter:
     description: |
-      두 개의 주요 커뮤니티 계정은 [twitter-together](https://github.com/twitter-together/action)로 운영됩니다. 트윗은 계정 저장소에 풀 리퀘스트로 제안되어 공개적으로 검토된 뒤, 병합되면 자동으로 게시됩니다. 가장 간단한 방법은 [ETC 기여 앱](https://etc.contributions.app)을 이용하는 것으로, GitHub 계정이 없어도 대신 풀 리퀘스트를 만들어 줍니다. `#ETCtweets` 태그가 달린 트윗에서도 아이디어를 모으며, 이는 Discord의 `#ETCtweets` 스레드에서 논의됩니다.
+      커뮤니티가 운영하는 두 계정은 [twitter-together](https://github.com/twitter-together/action)를 사용합니다. 트윗은 계정 저장소에 풀 리퀘스트로 제안되어 공개적으로 검토된 뒤, 병합되면 자동으로 게시됩니다. 가장 간단한 방법은 [ETC 기여 앱](https://etc.contributions.app)을 이용하는 것으로, GitHub 계정이 없어도 대신 풀 리퀘스트를 만들어 줍니다. `#ETCtweets` 태그가 달린 트윗에서도 아이디어를 모으며, 이는 Discord의 `#ETCtweets` 스레드에서 논의됩니다.
     items:
       twitterEthClassic:
         description: '두 계정 중 팔로워가 더 많은 쪽으로, 편집 지침에 따라 격식 있고 중립적이며 밈을 다루지 않습니다. 트윗은 [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic)에서 제안합니다.'

--- a/i18n/community/channels/index.ms.yaml
+++ b/i18n/community/channels/index.ms.yaml
@@ -1,17 +1,43 @@
 title: Saluran Sosial
-seo: Koleksi ruang sembang Ethereum Classic, akaun Twitter, kumpulan perbincangan, forum, podcast, repositori dan tapak web serantau.
+seo: 'Koleksi ruang sembang Ethereum Classic, akaun Twitter, kumpulan perbincangan, forum, podcast, repositori dan tapak web serantau.'
 description: |
-  Berikut ialah senarai saluran dan kumpulan perbincangan Ethereum Classic yang tidak lengkap.
+  Ethereum Classic tiada organisasi pusat, jadi tiada juga media sosial "rasmi"; setiap saluran yang disenaraikan di sini dikendalikan secara bebas oleh ahli komuniti.
 
-  Hab aktiviti utama dalam komuniti ETC pada masa ini adalah pada [Discord](https://ethereumclassic.org/discord).
+  Bahagian Discord, Telegram, Twitter dan Reddit merangkumi saluran yang dipautkan di pengaki laman web ini. Selebihnya ialah direktori tidak menyeluruh bagi kumpulan serantau dan kumpulan mengikut topik; sebahagiannya sudah lama tidak disemak, jadi ada pautan yang mungkin sudah lapuk.
 items:
-  Chat Rooms:
-    title: Bilik berbual
+  discord:
+    description: |
+      Terdapat dua pelayan Discord ETC untuk perbualan umum, kedua-duanya aktif. Kedua-duanya disenaraikan mengikut urutan penubuhan, tanpa keutamaan; sertai mana-mana yang sesuai dengan anda, atau kedua-duanya.
     items:
-      chat Discord:
-        name: Perselisihan (Komuniti, Global)
-      chat Discord Coop:
-        name: Perselisihan (ETC Coop)
+      discordClassic:
+        name: Discord Ethereum Classic
+        description: 'Pelayan komuniti asal, beroperasi sejak 2016, dan tempat berlangsungnya banyak panggilan pembangun teras serta panggilan komuniti yang lalu.'
+      discordCommunity:
+        name: Discord Komuniti Ethereum Classic
+        description: 'Pelayan yang lebih baharu, dilancarkan pada November 2025, dengan penyeliaan yang lebih ketat serta pengesahan automatik, perlindungan spam dan integrasi pengumuman. Lihat [siaran pengumuman](/blog/2025-11-05-discord-migration) untuk latar belakangnya.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Kumpulan di sekitar [ETC Grants DAO](https://etcgrantsdao.io), yang membiayai projek yang dibina di atas Ethereum Classic. Ia antara sembang ETC paling rancak, dengan ramai pengguna aktif membincangkan ekosistem setiap hari.'
+      telegramEnglish:
+        name: Ethereum Classic (Inggeris)
+        description: Kumpulan berbahasa Inggeris yang sudah lama wujud untuk perbualan umum tentang ETC.
+  twitter:
+    description: |
+      Dua akaun komuniti utama dikendalikan menerusi [twitter-together](https://github.com/twitter-together/action): tweet dicadangkan sebagai pull request dalam repositori akaun berkenaan, disemak secara terbuka, dan disiarkan secara automatik setelah digabungkan. Cara paling mudah untuk mencadangkan tweet ialah [aplikasi sumbangan ETC](https://etc.contributions.app), yang menghantar pull request bagi pihak anda, sama ada anda mempunyai akaun GitHub atau tidak. Idea turut diambil daripada tweet bertanda `#ETCtweets`, yang dibincangkan dalam bebenang `#ETCtweets` di Discord.
+    items:
+      twitterEthClassic:
+        description: 'Akaun yang lebih ramai pengikut antara kedua-duanya, dengan garis panduan penyuntingan yang mengekalkannya formal, neutral dan bebas meme. Tweet dicadangkan dalam [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Akaun yang kurang formal, di mana meme dan siaran yang lebih santai dibenarkan bersama berita rangkaian dan pembangunan. Tweet dicadangkan dalam [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Subreddit Ethereum Classic, digunakan untuk perbincangan yang lebih panjang, soalan, serta perkongsian berita dan pautan dari seluruh ekosistem.'
+  Chat Rooms:
+    title: Ruang Sembang Lain
+    items:
       chat Facebook English:
         name: Facebook (Bahasa Inggeris)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Kumpulan Telegram
+    title: Kumpulan Telegram Serantau
     items:
-      telegram English:
-        name: Inggeris
       telegram Español:
         name: Español
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Forum
+    title: Forum Lain
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Mari Berbincang DLL!
   Twitter Accounts:
-    title: Akaun Twitter
+    title: Akaun Twitter Serantau
     items:
       twitter China:
         name: China
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Español
       twitter France:

--- a/i18n/community/channels/index.ms.yaml
+++ b/i18n/community/channels/index.ms.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord Ethereum Classic
-        description: 'Pelayan komuniti asal, beroperasi sejak 2016, dan tempat berlangsungnya banyak panggilan pembangun teras serta panggilan komuniti yang lalu.'
+        description: 'Pelayan komuniti asal, beroperasi sejak 2016, dengan penyeliaan yang longgar, dan tempat berlangsungnya banyak panggilan pembangun teras serta panggilan komuniti yang lalu.'
       discordCommunity:
         name: Discord Komuniti Ethereum Classic
-        description: 'Pelayan yang lebih baharu, dilancarkan pada November 2025, dengan penyeliaan yang lebih ketat serta pengesahan automatik, perlindungan spam dan integrasi pengumuman. Lihat [siaran pengumuman](/blog/2025-11-05-discord-migration) untuk latar belakangnya.'
+        description: 'Pelayan yang lebih baharu, dilancarkan pada November 2025, dengan penyeliaan yang ketat serta pengesahan automatik, perlindungan spam dan integrasi pengumuman. Lihat [siaran pengumuman](/blog/2025-11-05-discord-migration) untuk latar belakangnya.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Kumpulan di sekitar [ETC Grants DAO](https://etcgrantsdao.io), yang membiayai projek yang dibina di atas Ethereum Classic. Ia antara sembang ETC paling rancak, dengan ramai pengguna aktif membincangkan ekosistem setiap hari.'
       telegramEnglish:
         name: Ethereum Classic (Inggeris)
         description: Kumpulan berbahasa Inggeris yang sudah lama wujud untuk perbualan umum tentang ETC.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Kumpulan di sekitar [ETC Grants DAO](https://etcgrantsdao.io), yang membiayai projek yang dibina di atas Ethereum Classic.'
   twitter:
     description: |
-      Dua akaun komuniti utama dikendalikan menerusi [twitter-together](https://github.com/twitter-together/action): tweet dicadangkan sebagai pull request dalam repositori akaun berkenaan, disemak secara terbuka, dan disiarkan secara automatik setelah digabungkan. Cara paling mudah untuk mencadangkan tweet ialah [aplikasi sumbangan ETC](https://etc.contributions.app), yang menghantar pull request bagi pihak anda, sama ada anda mempunyai akaun GitHub atau tidak. Idea turut diambil daripada tweet bertanda `#ETCtweets`, yang dibincangkan dalam bebenang `#ETCtweets` di Discord.
+      Dua akaun yang dikendalikan komuniti menggunakan [twitter-together](https://github.com/twitter-together/action): tweet dicadangkan sebagai pull request dalam repositori akaun berkenaan, disemak secara terbuka, dan disiarkan secara automatik setelah digabungkan. Cara paling mudah untuk mencadangkan tweet ialah [aplikasi sumbangan ETC](https://etc.contributions.app), yang menghantar pull request bagi pihak anda, sama ada anda mempunyai akaun GitHub atau tidak. Idea turut diambil daripada tweet bertanda `#ETCtweets`, yang dibincangkan dalam bebenang `#ETCtweets` di Discord.
     items:
       twitterEthClassic:
         description: 'Akaun yang lebih ramai pengikut antara kedua-duanya, dengan garis panduan penyuntingan yang mengekalkannya formal, neutral dan bebas meme. Tweet dicadangkan dalam [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.nl.yaml
+++ b/i18n/community/channels/index.nl.yaml
@@ -1,17 +1,43 @@
 title: Sociale kanalen
-seo: Een verzameling Ethereum Classic chat rooms, Twitter accounts, discussiegroepen, forums, podcasts, repositories en regionale websites.
+seo: 'Een verzameling Ethereum Classic chat rooms, Twitter accounts, discussiegroepen, forums, podcasts, repositories en regionale websites.'
 description: |
-  Hieronder volgt een niet-limitatieve lijst van actieve Ethereum Classic-discussiekanalen en -groepen.
+  Ethereum Classic heeft geen centrale organisatie en dus ook geen "officiële" sociale media; elk kanaal in deze lijst wordt onafhankelijk beheerd door leden van de gemeenschap.
 
-  Het belangrijkste centrum van activiteit binnen de ETC-gemeenschap bevindt zich momenteel op [Discord](https://ethereumclassic.org/discord).
+  De secties Discord, Telegram, Twitter en Reddit bevatten de kanalen waarnaar de voettekst van deze website verwijst. De rest is een niet-uitputtende gids van regionale groepen en groepen rond specifieke onderwerpen; delen daarvan zijn al een tijd niet nagekeken, dus sommige links kunnen verouderd zijn.
 items:
-  Chat Rooms:
-    title: Chatrooms
+  discord:
+    description: |
+      Er zijn twee algemene ETC-Discordservers, allebei actief. Ze staan hier in de volgorde waarin ze zijn opgericht, zonder voorkeur; sluit je aan bij de server die je het beste bevalt, of bij allebei.
     items:
-      chat Discord:
-        name: Discord (Gemeenschap, Wereldwijd)
-      chat Discord Coop:
-        name: Discord (ETC Coop)
+      discordClassic:
+        name: Ethereum Classic Discord
+        description: 'De oorspronkelijke gemeenschapsserver, actief sinds 2016, en het toneel van veel van de vroegere core devs calls en community calls.'
+      discordCommunity:
+        name: Ethereum Classic Community Discord
+        description: 'Een nieuwere server, gelanceerd in november 2025, die strenger wordt gemodereerd en werkt met automatische verificatie, spambescherming en aankondigingsintegraties. Zie het [aankondigingsbericht](/blog/2025-11-05-discord-migration) voor de achtergrond.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'De groep rond [ETC Grants DAO](https://etcgrantsdao.io), die projecten op Ethereum Classic financiert. Het is een van de drukste ETC-chats, met veel actieve gebruikers die dagelijks over het ecosysteem praten.'
+      telegramEnglish:
+        name: Ethereum Classic (Engels)
+        description: De al lang bestaande Engelstalige groep voor algemene gesprekken over ETC.
+  twitter:
+    description: |
+      De twee belangrijkste gemeenschapsaccounts draaien op [twitter-together](https://github.com/twitter-together/action): tweets worden als pull requests in de repository van het account voorgesteld, in de openbaarheid beoordeeld en automatisch geplaatst zodra ze zijn samengevoegd. De makkelijkste manier om er een voor te stellen is de [ETC Contributions-app](https://etc.contributions.app), die de pull request voor je indient, met of zonder GitHub-account. Ideeën worden ook opgepikt uit tweets met de hashtag `#ETCtweets`, die in de `#ETCtweets`-thread op Discord worden besproken.
+    items:
+      twitterEthClassic:
+        description: 'Het meest gevolgde van de twee accounts, met redactionele richtlijnen die het formeel, neutraal en vrij van memes houden. Tweets worden voorgesteld in [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Een minder formeel account, waar memes en luchtiger berichten zijn toegestaan naast nieuws over het netwerk en de ontwikkeling. Tweets worden voorgesteld in [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'De subreddit van Ethereum Classic, voor langere discussies, vragen en het delen van nieuws en links uit het hele ecosysteem.'
+  Chat Rooms:
+    title: Overige chatrooms
+    items:
       chat Facebook English:
         name: Facebook (Engels)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Telegram Groepen
+    title: Regionale Telegram-groepen
     items:
-      telegram English:
-        name: Engels
       telegram Español:
         name: Español
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Forums
+    title: Overige forums
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Let's Talk ETC!
   Twitter Accounts:
-    title: Twitter Accounts
+    title: Regionale Twitter-accounts
     items:
       twitter China:
         name: China
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Español
       twitter France:

--- a/i18n/community/channels/index.nl.yaml
+++ b/i18n/community/channels/index.nl.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Ethereum Classic Discord
-        description: 'De oorspronkelijke gemeenschapsserver, actief sinds 2016, en het toneel van veel van de vroegere core devs calls en community calls.'
+        description: 'De oorspronkelijke gemeenschapsserver, actief sinds 2016, die losjes wordt gemodereerd en het toneel was van veel van de vroegere core devs calls en community calls.'
       discordCommunity:
         name: Ethereum Classic Community Discord
-        description: 'Een nieuwere server, gelanceerd in november 2025, die strenger wordt gemodereerd en werkt met automatische verificatie, spambescherming en aankondigingsintegraties. Zie het [aankondigingsbericht](/blog/2025-11-05-discord-migration) voor de achtergrond.'
+        description: 'Een nieuwere server, gelanceerd in november 2025, die streng wordt gemodereerd en werkt met automatische verificatie, spambescherming en aankondigingsintegraties. Zie het [aankondigingsbericht](/blog/2025-11-05-discord-migration) voor de achtergrond.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'De groep rond [ETC Grants DAO](https://etcgrantsdao.io), die projecten op Ethereum Classic financiert. Het is een van de drukste ETC-chats, met veel actieve gebruikers die dagelijks over het ecosysteem praten.'
       telegramEnglish:
         name: Ethereum Classic (Engels)
         description: De al lang bestaande Engelstalige groep voor algemene gesprekken over ETC.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'De groep rond [ETC Grants DAO](https://etcgrantsdao.io), die projecten op Ethereum Classic financiert.'
   twitter:
     description: |
-      De twee belangrijkste gemeenschapsaccounts draaien op [twitter-together](https://github.com/twitter-together/action): tweets worden als pull requests in de repository van het account voorgesteld, in de openbaarheid beoordeeld en automatisch geplaatst zodra ze zijn samengevoegd. De makkelijkste manier om er een voor te stellen is de [ETC Contributions-app](https://etc.contributions.app), die de pull request voor je indient, met of zonder GitHub-account. Ideeën worden ook opgepikt uit tweets met de hashtag `#ETCtweets`, die in de `#ETCtweets`-thread op Discord worden besproken.
+      De twee door de gemeenschap beheerde accounts gebruiken [twitter-together](https://github.com/twitter-together/action): tweets worden als pull requests in de repository van het account voorgesteld, in de openbaarheid beoordeeld en automatisch geplaatst zodra ze zijn samengevoegd. De makkelijkste manier om er een voor te stellen is de [ETC Contributions-app](https://etc.contributions.app), die de pull request voor je indient, met of zonder GitHub-account. Ideeën worden ook opgepikt uit tweets met de hashtag `#ETCtweets`, die in de `#ETCtweets`-thread op Discord worden besproken.
     items:
       twitterEthClassic:
         description: 'Het meest gevolgde van de twee accounts, met redactionele richtlijnen die het formeel, neutraal en vrij van memes houden. Tweets worden voorgesteld in [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.pt.yaml
+++ b/i18n/community/channels/index.pt.yaml
@@ -1,17 +1,43 @@
 title: Canais sociais
-seo: Uma coleção de salas de bate-papo Ethereum Classic, contas do Twitter, grupos de discussão, fóruns, podcasts, repositórios e sites regionais.
+seo: 'Uma coleção de salas de bate-papo Ethereum Classic, contas do Twitter, grupos de discussão, fóruns, podcasts, repositórios e sites regionais.'
 description: |
-  A seguir, uma lista não exaustiva de canais e grupos de discussão ativos do Ethereum Classic.
+  A Ethereum Classic não tem uma organização central e, por isso, não tem redes sociais «oficiais»; cada canal listado aqui é mantido de forma independente por membros da comunidade.
 
-  O principal centro de atividade dentro da comunidade ETC no momento é em [Discord](https://ethereumclassic.org/discord).
+  As seções de Discord, Telegram, Twitter e Reddit reúnem os canais que estão no rodapé deste site. O restante é um diretório não exaustivo de grupos regionais e temáticos; algumas partes não são revisadas há um tempo, então alguns links podem estar desatualizados.
 items:
-  Chat Rooms:
-    title: Salas de conversa
+  discord:
+    description: |
+      Existem dois servidores de Discord do ETC de uso geral, ambos ativos. Eles estão listados na ordem em que foram criados, sem preferência; entre no que preferir, ou nos dois.
     items:
-      chat Discord:
-        name: Discord (Comunidade, Global)
-      chat Discord Coop:
-        name: Discord (ETC Coop)
+      discordClassic:
+        name: Discord do Ethereum Classic
+        description: 'O servidor original da comunidade, em funcionamento desde 2016, e palco de muitas das antigas chamadas dos core devs e das chamadas da comunidade.'
+      discordCommunity:
+        name: Discord da Comunidade Ethereum Classic
+        description: 'Um servidor mais recente, lançado em novembro de 2025, com moderação mais rígida e com verificação automática, proteção contra spam e integrações de anúncios. Veja o [post de anúncio](/blog/2025-11-05-discord-migration) para entender o contexto.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'O grupo da [ETC Grants DAO](https://etcgrantsdao.io), que financia projetos construídos sobre a Ethereum Classic. É um dos bate-papos de ETC mais movimentados, com muitos usuários ativos discutindo o dia a dia do ecossistema.'
+      telegramEnglish:
+        name: Ethereum Classic (inglês)
+        description: 'O grupo em inglês mais antigo, para conversas gerais sobre ETC.'
+  twitter:
+    description: |
+      As duas contas principais da comunidade funcionam com o [twitter-together](https://github.com/twitter-together/action): os tweets são propostos como pull requests no repositório da conta, revisados de forma aberta e publicados automaticamente assim que são mesclados. O jeito mais simples de propor um é o [app de contribuições do ETC](https://etc.contributions.app), que abre o pull request para você, com ou sem uma conta no GitHub. Também surgem ideias dos tweets marcados com `#ETCtweets`, que são discutidos no tópico `#ETCtweets` do Discord.
+    items:
+      twitterEthClassic:
+        description: 'A mais seguida das duas contas, com diretrizes editoriais que a mantêm formal, neutra e sem memes. Os tweets são propostos em [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Uma conta menos formal, onde memes e publicações mais leves são permitidos junto com as novidades da rede e do desenvolvimento. Os tweets são propostos em [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'O subreddit da Ethereum Classic, usado para discussões mais longas, perguntas e para compartilhar notícias e links de todo o ecossistema.'
+  Chat Rooms:
+    title: Outras salas de conversa
+    items:
       chat Facebook English:
         name: Facebook (inglês)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Grupos do Telegram
+    title: Grupos regionais do Telegram
     items:
-      telegram English:
-        name: Inglês
       telegram Español:
         name: espanhol
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Fóruns
+    title: Outros fóruns
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: Bitcoin Talk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Vamos Conversar ETC!
   Twitter Accounts:
-    title: Contas do Twitter
+    title: Contas regionais do Twitter
     items:
       twitter China:
         name: China
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: espanhol
       twitter France:

--- a/i18n/community/channels/index.pt.yaml
+++ b/i18n/community/channels/index.pt.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord do Ethereum Classic
-        description: 'O servidor original da comunidade, em funcionamento desde 2016, e palco de muitas das antigas chamadas dos core devs e das chamadas da comunidade.'
+        description: 'O servidor original da comunidade, em funcionamento desde 2016, com moderação leve, e palco de muitas das antigas chamadas dos core devs e das chamadas da comunidade.'
       discordCommunity:
         name: Discord da Comunidade Ethereum Classic
-        description: 'Um servidor mais recente, lançado em novembro de 2025, com moderação mais rígida e com verificação automática, proteção contra spam e integrações de anúncios. Veja o [post de anúncio](/blog/2025-11-05-discord-migration) para entender o contexto.'
+        description: 'Um servidor mais recente, lançado em novembro de 2025, com moderação rígida e com verificação automática, proteção contra spam e integrações de anúncios. Veja o [post de anúncio](/blog/2025-11-05-discord-migration) para entender o contexto.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'O grupo da [ETC Grants DAO](https://etcgrantsdao.io), que financia projetos construídos sobre a Ethereum Classic. É um dos bate-papos de ETC mais movimentados, com muitos usuários ativos discutindo o dia a dia do ecossistema.'
       telegramEnglish:
         name: Ethereum Classic (inglês)
         description: 'O grupo em inglês mais antigo, para conversas gerais sobre ETC.'
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'O grupo da [ETC Grants DAO](https://etcgrantsdao.io), que financia projetos construídos sobre a Ethereum Classic.'
   twitter:
     description: |
-      As duas contas principais da comunidade funcionam com o [twitter-together](https://github.com/twitter-together/action): os tweets são propostos como pull requests no repositório da conta, revisados de forma aberta e publicados automaticamente assim que são mesclados. O jeito mais simples de propor um é o [app de contribuições do ETC](https://etc.contributions.app), que abre o pull request para você, com ou sem uma conta no GitHub. Também surgem ideias dos tweets marcados com `#ETCtweets`, que são discutidos no tópico `#ETCtweets` do Discord.
+      As duas contas administradas pela comunidade usam o [twitter-together](https://github.com/twitter-together/action): os tweets são propostos como pull requests no repositório da conta, revisados de forma aberta e publicados automaticamente assim que são mesclados. O jeito mais simples de propor um é o [app de contribuições do ETC](https://etc.contributions.app), que abre o pull request para você, com ou sem uma conta no GitHub. Também surgem ideias dos tweets marcados com `#ETCtweets`, que são discutidos no tópico `#ETCtweets` do Discord.
     items:
       twitterEthClassic:
         description: 'A mais seguida das duas contas, com diretrizes editoriais que a mantêm formal, neutra e sem memes. Os tweets são propostos em [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.ru.yaml
+++ b/i18n/community/channels/index.ru.yaml
@@ -1,17 +1,43 @@
 title: Социальные каналы
-seo: Коллекция чатов Ethereum Classic, аккаунтов Twitter, дискуссионных групп, форумов, подкастов, репозиториев и региональных сайтов.
+seo: 'Коллекция чатов Ethereum Classic, аккаунтов Twitter, дискуссионных групп, форумов, подкастов, репозиториев и региональных сайтов.'
 description: |
-  Ниже представлен неполный список активных дискуссионных каналов и групп Ethereum Classic.
+  У Ethereum Classic нет центральной организации, а значит, нет и «официальных» социальных сетей: каждый канал в этом списке ведут независимо друг от друга члены сообщества.
 
-  В настоящее время основной центр активности сообщества ETC находится на сайте [Discord](https://ethereumclassic.org/discord).
+  Разделы Discord, Telegram, Twitter и Reddit охватывают каналы, ссылки на которые есть в нижнем колонтитуле этого сайта. Остальное — неполный каталог региональных и тематических групп; часть его давно не проверялась, поэтому некоторые ссылки могут устареть.
 items:
-  Chat Rooms:
-    title: Чат-комнаты
+  discord:
+    description: |
+      Существует два общих сервера ETC в Discord, оба активны. Они перечислены в порядке создания, без какого-либо предпочтения; присоединяйтесь к тому, который вам ближе, или сразу к обоим.
     items:
-      chat Discord:
-        name: Discord (сообщество, глобальный)
-      chat Discord Coop:
-        name: Discord (ETC Coop)
+      discordClassic:
+        name: Discord Ethereum Classic
+        description: 'Первоначальный сервер сообщества, работающий с 2016 года, площадка многих прошедших созвонов core-разработчиков и созвонов сообщества.'
+      discordCommunity:
+        name: Discord сообщества Ethereum Classic
+        description: 'Более новый сервер, запущенный в ноябре 2025 года, с более строгой модерацией, автоматической верификацией, защитой от спама и интеграциями для объявлений. Подробности — в [публикации с анонсом](/blog/2025-11-05-discord-migration).'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Группа вокруг [ETC Grants DAO](https://etcgrantsdao.io), которая финансирует проекты на Ethereum Classic. Это один из самых оживлённых чатов ETC: в нём много активных участников, ежедневно обсуждающих экосистему.'
+      telegramEnglish:
+        name: Ethereum Classic (английский)
+        description: Давно существующая англоязычная группа для общих разговоров об ETC.
+  twitter:
+    description: |
+      Два основных аккаунта сообщества работают через [twitter-together](https://github.com/twitter-together/action): твиты предлагаются как pull request в репозитории аккаунта, открыто рецензируются и публикуются автоматически после слияния. Проще всего предложить твит через [приложение ETC Contributions](https://etc.contributions.app), которое создаёт pull request за вас — с учётной записью GitHub или без неё. Идеи также берут из твитов с хештегом `#ETCtweets`, которые обсуждаются в ветке `#ETCtweets` в Discord.
+    items:
+      twitterEthClassic:
+        description: 'Более популярный из двух аккаунтов; редакционные правила держат его формальным, нейтральным и без мемов. Твиты предлагаются в [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Менее формальный аккаунт, где наряду с новостями о сети и разработке допускаются мемы и более лёгкие публикации. Твиты предлагаются в [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Сабреддит Ethereum Classic — для развёрнутых обсуждений, вопросов и обмена новостями и ссылками со всей экосистемы.'
+  Chat Rooms:
+    title: Другие чаты
+    items:
       chat Facebook English:
         name: Facebook (на английском языке)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Группы Telegram
+    title: Региональные группы в Telegram
     items:
-      telegram English:
-        name: Английский язык
       telegram Español:
         name: Español
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Форумы
+    title: Другие форумы
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Давайте поговорим о ETC!
   Twitter Accounts:
-    title: Twitter-аккаунты
+    title: Региональные аккаунты в Twitter
     items:
       twitter China:
         name: Китай
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Español
       twitter France:

--- a/i18n/community/channels/index.ru.yaml
+++ b/i18n/community/channels/index.ru.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord Ethereum Classic
-        description: 'Первоначальный сервер сообщества, работающий с 2016 года, площадка многих прошедших созвонов core-разработчиков и созвонов сообщества.'
+        description: 'Первоначальный сервер сообщества, работающий с 2016 года, с мягкой модерацией, площадка многих прошедших созвонов core-разработчиков и созвонов сообщества.'
       discordCommunity:
         name: Discord сообщества Ethereum Classic
-        description: 'Более новый сервер, запущенный в ноябре 2025 года, с более строгой модерацией, автоматической верификацией, защитой от спама и интеграциями для объявлений. Подробности — в [публикации с анонсом](/blog/2025-11-05-discord-migration).'
+        description: 'Более новый сервер, запущенный в ноябре 2025 года, со строгой модерацией, автоматической верификацией, защитой от спама и интеграциями для объявлений. Подробности — в [публикации с анонсом](/blog/2025-11-05-discord-migration).'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Группа вокруг [ETC Grants DAO](https://etcgrantsdao.io), которая финансирует проекты на Ethereum Classic. Это один из самых оживлённых чатов ETC: в нём много активных участников, ежедневно обсуждающих экосистему.'
       telegramEnglish:
         name: Ethereum Classic (английский)
         description: Давно существующая англоязычная группа для общих разговоров об ETC.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Группа вокруг [ETC Grants DAO](https://etcgrantsdao.io), которая финансирует проекты на Ethereum Classic.'
   twitter:
     description: |
-      Два основных аккаунта сообщества работают через [twitter-together](https://github.com/twitter-together/action): твиты предлагаются как pull request в репозитории аккаунта, открыто рецензируются и публикуются автоматически после слияния. Проще всего предложить твит через [приложение ETC Contributions](https://etc.contributions.app), которое создаёт pull request за вас — с учётной записью GitHub или без неё. Идеи также берут из твитов с хештегом `#ETCtweets`, которые обсуждаются в ветке `#ETCtweets` в Discord.
+      Два аккаунта, которыми управляет сообщество, используют [twitter-together](https://github.com/twitter-together/action): твиты предлагаются как pull request в репозитории аккаунта, открыто рецензируются и публикуются автоматически после слияния. Проще всего предложить твит через [приложение ETC Contributions](https://etc.contributions.app), которое создаёт pull request за вас — с учётной записью GitHub или без неё. Идеи также берут из твитов с хештегом `#ETCtweets`, которые обсуждаются в ветке `#ETCtweets` в Discord.
     items:
       twitterEthClassic:
         description: 'Более популярный из двух аккаунтов; редакционные правила держат его формальным, нейтральным и без мемов. Твиты предлагаются в [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.th.yaml
+++ b/i18n/community/channels/index.th.yaml
@@ -1,17 +1,43 @@
 title: ช่องโซเชียล
-seo: คอลเลกชันของห้องสนทนา Ethereum Classic, บัญชี Twitter, กลุ่มสนทนา, ฟอรัม, พอดคาสต์, ที่เก็บ และเว็บไซต์ระดับภูมิภาค
+seo: 'คอลเลกชันของห้องสนทนา Ethereum Classic, บัญชี Twitter, กลุ่มสนทนา, ฟอรัม, พอดคาสต์, ที่เก็บ และเว็บไซต์ระดับภูมิภาค'
 description: |
-  ต่อไปนี้คือรายการโดยย่อของช่องทางและกลุ่มสนทนา Ethereum Classic ที่ใช้งานอยู่
+  Ethereum Classic ไม่มีองค์กรกลาง จึงไม่มีโซเชียลมีเดีย "อย่างเป็นทางการ" ทุกช่องทางที่แสดงไว้ที่นี่ดำเนินการโดยสมาชิกในชุมชนอย่างเป็นอิสระ
 
-  ศูนย์กลางกิจกรรมหลักภายในชุมชน ETC ปัจจุบันอยู่ที่ [Discord](https://ethereumclassic.org/discord)
+  ส่วน Discord, Telegram, Twitter และ Reddit ครอบคลุมช่องทางที่ลิงก์ไว้ในส่วนท้ายของเว็บไซต์นี้ ส่วนที่เหลือเป็นรายชื่อกลุ่มตามภูมิภาคและตามหัวข้อซึ่งไม่ครบถ้วน บางส่วนไม่ได้ตรวจสอบมาสักระยะแล้ว ลิงก์บางรายการจึงอาจล้าสมัย
 items:
-  Chat Rooms:
-    title: ห้องแชท
+  discord:
+    description: |
+      มีเซิร์ฟเวอร์ Discord ของ ETC สำหรับการพูดคุยทั่วไปอยู่สองแห่ง และทั้งสองแห่งยังใช้งานอยู่ รายการนี้เรียงตามลำดับการก่อตั้งโดยไม่ได้จัดลำดับความสำคัญ คุณจะเข้าร่วมแห่งที่ถูกใจ หรือทั้งสองแห่งก็ได้
     items:
-      chat Discord:
-        name: ความไม่ลงรอยกัน (ชุมชน, ทั่วโลก)
-      chat Discord Coop:
-        name: ความไม่ลงรอยกัน (ETC Coop)
+      discordClassic:
+        name: Discord ของ Ethereum Classic
+        description: เซิร์ฟเวอร์ชุมชนดั้งเดิม เปิดใช้งานมาตั้งแต่ปี 2016 และเป็นสถานที่จัดการประชุมนักพัฒนาหลักและการประชุมชุมชนหลายครั้งในอดีต
+      discordCommunity:
+        name: Discord ชุมชน Ethereum Classic
+        description: 'เซิร์ฟเวอร์ใหม่กว่า เปิดตัวเมื่อเดือนพฤศจิกายน 2025 มีการกำกับดูแลที่เข้มงวดกว่า พร้อมระบบยืนยันตัวตนอัตโนมัติ การป้องกันสแปม และการเชื่อมต่อประกาศต่าง ๆ อ่านที่มาได้จาก[โพสต์ประกาศ](/blog/2025-11-05-discord-migration)'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'กลุ่มของ [ETC Grants DAO](https://etcgrantsdao.io) ซึ่งให้ทุนแก่โครงการที่พัฒนาบน Ethereum Classic เป็นหนึ่งในห้องแชท ETC ที่คึกคักที่สุด มีผู้ใช้ที่ใช้งานอยู่จำนวนมากพูดคุยเรื่องระบบนิเวศกันทุกวัน'
+      telegramEnglish:
+        name: Ethereum Classic (ภาษาอังกฤษ)
+        description: กลุ่มภาษาอังกฤษที่เปิดมายาวนานสำหรับพูดคุยเรื่อง ETC ทั่วไป
+  twitter:
+    description: |
+      บัญชีหลักของชุมชนทั้งสองดำเนินการผ่าน [twitter-together](https://github.com/twitter-together/action) ทวีตจะถูกเสนอเป็น pull request ในที่เก็บโค้ดของบัญชีนั้น ผ่านการตรวจทานอย่างเปิดเผย และเผยแพร่โดยอัตโนมัติเมื่อผสานแล้ว วิธีที่ง่ายที่สุดคือใช้[แอปการมีส่วนร่วมของ ETC](https://etc.contributions.app) ซึ่งจะส่ง pull request ให้คุณ ไม่ว่าคุณจะมีบัญชี GitHub หรือไม่ก็ตาม นอกจากนี้ยังรวบรวมแนวคิดจากทวีตที่ติดแท็ก `#ETCtweets` ซึ่งพูดคุยกันในเธรด `#ETCtweets` บน Discord
+    items:
+      twitterEthClassic:
+        description: 'บัญชีที่มีผู้ติดตามมากกว่าในสองบัญชี โดยมีแนวทางการเขียนที่ทำให้เนื้อหาเป็นทางการ เป็นกลาง และไม่มีมีม เสนอทวีตได้ที่ [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic)'
+      twitterEtcNetwork:
+        description: 'บัญชีที่เป็นทางการน้อยกว่า อนุญาตให้มีมและโพสต์เบา ๆ ควบคู่ไปกับข่าวสารด้านเครือข่ายและการพัฒนา เสนอทวีตได้ที่ [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network)'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: ซับเรดดิตของ Ethereum Classic ใช้สำหรับการพูดคุยแบบยาว การตั้งคำถาม และแบ่งปันข่าวสารกับลิงก์จากทั่วทั้งระบบนิเวศ
+  Chat Rooms:
+    title: ห้องแชทอื่น ๆ
+    items:
       chat Facebook English:
         name: เฟสบุ๊ค (ภาษาอังกฤษ)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: กลุ่มโทรเลข
+    title: กลุ่ม Telegram ตามภูมิภาค
     items:
-      telegram English:
-        name: ภาษาอังกฤษ
       telegram Español:
         name: ภาษาสเปน
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: ฟอรั่ม
+    title: ฟอรัมอื่น ๆ
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: มาคุยกัน ETC!
   Twitter Accounts:
-    title: บัญชีทวิตเตอร์
+    title: บัญชี Twitter ตามภูมิภาค
     items:
       twitter China:
         name: จีน
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: ภาษาสเปน
       twitter France:

--- a/i18n/community/channels/index.th.yaml
+++ b/i18n/community/channels/index.th.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord ของ Ethereum Classic
-        description: เซิร์ฟเวอร์ชุมชนดั้งเดิม เปิดใช้งานมาตั้งแต่ปี 2016 และเป็นสถานที่จัดการประชุมนักพัฒนาหลักและการประชุมชุมชนหลายครั้งในอดีต
+        description: เซิร์ฟเวอร์ชุมชนดั้งเดิม เปิดใช้งานมาตั้งแต่ปี 2016 มีการกำกับดูแลแบบผ่อนปรน และเป็นสถานที่จัดการประชุมนักพัฒนาหลักและการประชุมชุมชนหลายครั้งในอดีต
       discordCommunity:
         name: Discord ชุมชน Ethereum Classic
-        description: 'เซิร์ฟเวอร์ใหม่กว่า เปิดตัวเมื่อเดือนพฤศจิกายน 2025 มีการกำกับดูแลที่เข้มงวดกว่า พร้อมระบบยืนยันตัวตนอัตโนมัติ การป้องกันสแปม และการเชื่อมต่อประกาศต่าง ๆ อ่านที่มาได้จาก[โพสต์ประกาศ](/blog/2025-11-05-discord-migration)'
+        description: 'เซิร์ฟเวอร์ใหม่กว่า เปิดตัวเมื่อเดือนพฤศจิกายน 2025 มีการกำกับดูแลที่เข้มงวด พร้อมระบบยืนยันตัวตนอัตโนมัติ การป้องกันสแปม และการเชื่อมต่อประกาศต่าง ๆ อ่านที่มาได้จาก[โพสต์ประกาศ](/blog/2025-11-05-discord-migration)'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'กลุ่มของ [ETC Grants DAO](https://etcgrantsdao.io) ซึ่งให้ทุนแก่โครงการที่พัฒนาบน Ethereum Classic เป็นหนึ่งในห้องแชท ETC ที่คึกคักที่สุด มีผู้ใช้ที่ใช้งานอยู่จำนวนมากพูดคุยเรื่องระบบนิเวศกันทุกวัน'
       telegramEnglish:
         name: Ethereum Classic (ภาษาอังกฤษ)
         description: กลุ่มภาษาอังกฤษที่เปิดมายาวนานสำหรับพูดคุยเรื่อง ETC ทั่วไป
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'กลุ่มของ [ETC Grants DAO](https://etcgrantsdao.io) ซึ่งให้ทุนแก่โครงการที่พัฒนาบน Ethereum Classic'
   twitter:
     description: |
-      บัญชีหลักของชุมชนทั้งสองดำเนินการผ่าน [twitter-together](https://github.com/twitter-together/action) ทวีตจะถูกเสนอเป็น pull request ในที่เก็บโค้ดของบัญชีนั้น ผ่านการตรวจทานอย่างเปิดเผย และเผยแพร่โดยอัตโนมัติเมื่อผสานแล้ว วิธีที่ง่ายที่สุดคือใช้[แอปการมีส่วนร่วมของ ETC](https://etc.contributions.app) ซึ่งจะส่ง pull request ให้คุณ ไม่ว่าคุณจะมีบัญชี GitHub หรือไม่ก็ตาม นอกจากนี้ยังรวบรวมแนวคิดจากทวีตที่ติดแท็ก `#ETCtweets` ซึ่งพูดคุยกันในเธรด `#ETCtweets` บน Discord
+      บัญชีทั้งสองที่ชุมชนดูแลใช้ [twitter-together](https://github.com/twitter-together/action) ทวีตจะถูกเสนอเป็น pull request ในที่เก็บโค้ดของบัญชีนั้น ผ่านการตรวจทานอย่างเปิดเผย และเผยแพร่โดยอัตโนมัติเมื่อผสานแล้ว วิธีที่ง่ายที่สุดคือใช้[แอปการมีส่วนร่วมของ ETC](https://etc.contributions.app) ซึ่งจะส่ง pull request ให้คุณ ไม่ว่าคุณจะมีบัญชี GitHub หรือไม่ก็ตาม นอกจากนี้ยังรวบรวมแนวคิดจากทวีตที่ติดแท็ก `#ETCtweets` ซึ่งพูดคุยกันในเธรด `#ETCtweets` บน Discord
     items:
       twitterEthClassic:
         description: 'บัญชีที่มีผู้ติดตามมากกว่าในสองบัญชี โดยมีแนวทางการเขียนที่ทำให้เนื้อหาเป็นทางการ เป็นกลาง และไม่มีมีม เสนอทวีตได้ที่ [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic)'

--- a/i18n/community/channels/index.tr.yaml
+++ b/i18n/community/channels/index.tr.yaml
@@ -1,17 +1,43 @@
 title: Sosyal Kanallar
-seo: Ethereum Classic sohbet odaları, Twitter hesapları, tartışma grupları, forumlar, podcast'ler, depolar ve bölgesel web sitelerinden oluşan bir koleksiyon.
+seo: 'Ethereum Classic sohbet odaları, Twitter hesapları, tartışma grupları, forumlar, podcast''ler, depolar ve bölgesel web sitelerinden oluşan bir koleksiyon.'
 description: |
-  Aşağıda, aktif Ethereum Classic tartışma kanallarının ve gruplarının kapsamlı olmayan bir listesi yer almaktadır.
+  Ethereum Classic'in merkezi bir organizasyonu yoktur, dolayısıyla "resmi" bir sosyal medya hesabı da yoktur; burada listelenen her kanal topluluk üyeleri tarafından bağımsız olarak yürütülür.
 
-  Şu anda ETC topluluğu içindeki ana faaliyet merkezi [Discord](https://ethereumclassic.org/discord) adresindedir.
+  Discord, Telegram, Twitter ve Reddit bölümleri bu sitenin alt bilgisinde bağlantısı verilen kanalları kapsar. Geri kalanı, bölgesel ve konuya özel grupların tamamını kapsamayan bir dizinidir; bir süredir gözden geçirilmeyen kısımları var, bu yüzden bazı bağlantılar güncelliğini yitirmiş olabilir.
 items:
-  Chat Rooms:
-    title: Sohbet Odaları
+  discord:
+    description: |
+      İkisi de aktif olan, genel amaçlı iki ETC Discord sunucusu var. Kuruldukları sıraya göre, herhangi bir tercih belirtilmeden listelenmiştir; hangisi size uyuyorsa ona ya da ikisine birden katılabilirsiniz.
     items:
-      chat Discord:
-        name: Discord (Topluluk, Küresel)
-      chat Discord Coop:
-        name: Discord (ETC Coop)
+      discordClassic:
+        name: Ethereum Classic Discord
+        description: 2016'dan beri çalışan ilk topluluk sunucusu; geçmişteki core dev çağrılarının ve topluluk çağrılarının çoğuna ev sahipliği yaptı.
+      discordCommunity:
+        name: Ethereum Classic Community Discord
+        description: 'Kasım 2025''te açılan, daha sıkı denetlenen ve otomatik doğrulama, spam koruması ile duyuru entegrasyonları çalıştıran daha yeni bir sunucu. Ayrıntılar için [duyuru yazısına](/blog/2025-11-05-discord-migration) bakın.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Ethereum Classic üzerinde geliştirilen projeleri fonlayan [ETC Grants DAO](https://etcgrantsdao.io) etrafındaki grup. Ekosistemi her gün konuşan çok sayıda aktif kullanıcısıyla en hareketli ETC sohbetlerinden biri.'
+      telegramEnglish:
+        name: Ethereum Classic (İngilizce)
+        description: Genel ETC sohbeti için uzun süredir var olan İngilizce grup.
+  twitter:
+    description: |
+      Topluluğun iki ana hesabı [twitter-together](https://github.com/twitter-together/action) ile yürütülür: tweetler hesabın deposuna pull request olarak önerilir, herkese açık şekilde incelenir ve birleştirildiğinde otomatik olarak paylaşılır. Tweet önermenin en kolay yolu, GitHub hesabı olsun ya da olmasın pull request'i sizin yerinize açan [ETC Contributions uygulamasıdır](https://etc.contributions.app). Ayrıca `#ETCtweets` etiketli tweetlerden fikirler derlenir ve bunlar Discord'daki `#ETCtweets` başlığında tartışılır.
+    items:
+      twitterEthClassic:
+        description: 'İki hesaptan daha çok takip edileni; yayın ilkeleri onu resmi, tarafsız ve mizah paylaşımlarından uzak tutar. Tweetler [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) deposunda önerilir.'
+      twitterEtcNetwork:
+        description: 'Ağ ve geliştirme haberlerinin yanında mizahi ve daha rahat paylaşımlara da izin veren, daha az resmi bir hesap. Tweetler [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network) deposunda önerilir.'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Ethereum Classic subreddit''i; daha uzun tartışmalar, sorular ve ekosistemin her yerinden haber ve bağlantı paylaşmak için kullanılır.'
+  Chat Rooms:
+    title: Diğer Sohbet Odaları
+    items:
       chat Facebook English:
         name: Facebook (İngilizce)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Telegram Grupları
+    title: Bölgesel Telegram Grupları
     items:
-      telegram English:
-        name: İngilizce
       telegram Español:
         name: Español
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Forumlar
+    title: Diğer Forumlar
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: ETC'yi Konuşalım!
   Twitter Accounts:
-    title: Twitter Hesapları
+    title: Bölgesel Twitter Hesapları
     items:
       twitter China:
         name: Çin
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Español
       twitter France:

--- a/i18n/community/channels/index.tr.yaml
+++ b/i18n/community/channels/index.tr.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Ethereum Classic Discord
-        description: 2016'dan beri çalışan ilk topluluk sunucusu; geçmişteki core dev çağrılarının ve topluluk çağrılarının çoğuna ev sahipliği yaptı.
+        description: 2016'dan beri çalışan, gevşek denetlenen ilk topluluk sunucusu; geçmişteki core dev çağrılarının ve topluluk çağrılarının çoğuna ev sahipliği yaptı.
       discordCommunity:
         name: Ethereum Classic Community Discord
-        description: 'Kasım 2025''te açılan, daha sıkı denetlenen ve otomatik doğrulama, spam koruması ile duyuru entegrasyonları çalıştıran daha yeni bir sunucu. Ayrıntılar için [duyuru yazısına](/blog/2025-11-05-discord-migration) bakın.'
+        description: 'Kasım 2025''te açılan, sıkı denetlenen ve otomatik doğrulama, spam koruması ile duyuru entegrasyonları çalıştıran daha yeni bir sunucu. Ayrıntılar için [duyuru yazısına](/blog/2025-11-05-discord-migration) bakın.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Ethereum Classic üzerinde geliştirilen projeleri fonlayan [ETC Grants DAO](https://etcgrantsdao.io) etrafındaki grup. Ekosistemi her gün konuşan çok sayıda aktif kullanıcısıyla en hareketli ETC sohbetlerinden biri.'
       telegramEnglish:
         name: Ethereum Classic (İngilizce)
         description: Genel ETC sohbeti için uzun süredir var olan İngilizce grup.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Ethereum Classic üzerinde geliştirilen projeleri fonlayan [ETC Grants DAO](https://etcgrantsdao.io) etrafındaki grup.'
   twitter:
     description: |
-      Topluluğun iki ana hesabı [twitter-together](https://github.com/twitter-together/action) ile yürütülür: tweetler hesabın deposuna pull request olarak önerilir, herkese açık şekilde incelenir ve birleştirildiğinde otomatik olarak paylaşılır. Tweet önermenin en kolay yolu, GitHub hesabı olsun ya da olmasın pull request'i sizin yerinize açan [ETC Contributions uygulamasıdır](https://etc.contributions.app). Ayrıca `#ETCtweets` etiketli tweetlerden fikirler derlenir ve bunlar Discord'daki `#ETCtweets` başlığında tartışılır.
+      Topluluğun yürüttüğü iki hesap [twitter-together](https://github.com/twitter-together/action) kullanır: tweetler hesabın deposuna pull request olarak önerilir, herkese açık şekilde incelenir ve birleştirildiğinde otomatik olarak paylaşılır. Tweet önermenin en kolay yolu, GitHub hesabı olsun ya da olmasın pull request'i sizin yerinize açan [ETC Contributions uygulamasıdır](https://etc.contributions.app). Ayrıca `#ETCtweets` etiketli tweetlerden fikirler derlenir ve bunlar Discord'daki `#ETCtweets` başlığında tartışılır.
     items:
       twitterEthClassic:
         description: 'İki hesaptan daha çok takip edileni; yayın ilkeleri onu resmi, tarafsız ve mizah paylaşımlarından uzak tutar. Tweetler [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) deposunda önerilir.'

--- a/i18n/community/channels/index.vi.yaml
+++ b/i18n/community/channels/index.vi.yaml
@@ -1,17 +1,43 @@
 title: Kênh xã hội
-seo: Tập hợp các phòng trò chuyện Ethereum Classic, tài khoản Twitter, nhóm thảo luận, diễn đàn, podcast, kho lưu trữ và các trang web khu vực.
+seo: 'Tập hợp các phòng trò chuyện Ethereum Classic, tài khoản Twitter, nhóm thảo luận, diễn đàn, podcast, kho lưu trữ và các trang web khu vực.'
 description: |
-  Sau đây là danh sách không đầy đủ các kênh và nhóm thảo luận Ethereum Classic đang hoạt động.
+  Ethereum Classic không có tổ chức trung tâm, vì vậy cũng không có mạng xã hội "chính thức"; mọi kênh được liệt kê ở đây đều do các thành viên cộng đồng tự vận hành một cách độc lập.
 
-  Trung tâm hoạt động chính trong cộng đồng ETC hiện tại là trên [Discord](https://ethereumclassic.org/discord).
+  Các mục Discord, Telegram, Twitter và Reddit bao gồm những kênh được liên kết ở chân trang của trang web này. Phần còn lại là danh mục chưa đầy đủ về các nhóm theo khu vực và theo chủ đề; một số phần đã lâu không được rà soát nên có thể còn liên kết cũ.
 items:
-  Chat Rooms:
-    title: Các phòng chat
+  discord:
+    description: |
+      Hiện có hai máy chủ Discord ETC dùng chung, cả hai đều đang hoạt động. Chúng được liệt kê theo thứ tự thành lập, không ưu tiên máy chủ nào; bạn có thể tham gia máy chủ phù hợp với mình, hoặc cả hai.
     items:
-      chat Discord:
-        name: Bất hòa (Cộng đồng, Toàn cầu)
-      chat Discord Coop:
-        name: Sự bất hòa (ETC Coop)
+      discordClassic:
+        name: Discord Ethereum Classic
+        description: 'Máy chủ cộng đồng đầu tiên, hoạt động từ năm 2016, nơi đã diễn ra nhiều cuộc gọi của các nhà phát triển cốt lõi và các cuộc gọi cộng đồng trước đây.'
+      discordCommunity:
+        name: Discord Cộng đồng Ethereum Classic
+        description: 'Máy chủ mới hơn, ra mắt vào tháng 11 năm 2025, được kiểm duyệt chặt chẽ hơn và có xác minh tự động, chống thư rác cùng các tích hợp thông báo. Xem [bài đăng thông báo](/blog/2025-11-05-discord-migration) để biết bối cảnh.'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Nhóm xoay quanh [ETC Grants DAO](https://etcgrantsdao.io), tổ chức tài trợ cho các dự án xây dựng trên Ethereum Classic. Đây là một trong những nhóm trò chuyện ETC sôi nổi nhất, với nhiều người dùng tích cực bàn luận về hệ sinh thái mỗi ngày.'
+      telegramEnglish:
+        name: Ethereum Classic (tiếng Anh)
+        description: Nhóm tiếng Anh lâu đời để trò chuyện chung về ETC.
+  twitter:
+    description: |
+      Hai tài khoản cộng đồng chính được vận hành bằng [twitter-together](https://github.com/twitter-together/action): các tweet được đề xuất dưới dạng pull request vào kho lưu trữ của tài khoản, được xem xét công khai và tự động đăng khi hợp nhất. Cách đơn giản nhất để đề xuất là dùng [ứng dụng đóng góp ETC](https://etc.contributions.app), ứng dụng này sẽ gửi pull request thay bạn, dù bạn có tài khoản GitHub hay không. Ý tưởng cũng được lấy từ các tweet gắn thẻ `#ETCtweets` và được thảo luận trong luồng `#ETCtweets` trên Discord.
+    items:
+      twitterEthClassic:
+        description: 'Tài khoản có nhiều người theo dõi hơn trong hai tài khoản, với quy tắc biên tập giữ cho nội dung trang trọng, trung lập và không đăng meme. Tweet được đề xuất tại [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'
+      twitterEtcNetwork:
+        description: 'Tài khoản ít trang trọng hơn, nơi meme và các bài đăng nhẹ nhàng được chấp nhận bên cạnh tin tức về mạng lưới và phát triển. Tweet được đề xuất tại [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network).'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: 'Subreddit của Ethereum Classic, dùng cho những thảo luận dài hơn, đặt câu hỏi và chia sẻ tin tức, liên kết từ khắp hệ sinh thái.'
+  Chat Rooms:
+    title: Phòng trò chuyện khác
+    items:
       chat Facebook English:
         name: Facebook (tiếng Anh)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: Nhóm Telegram
+    title: Nhóm Telegram theo khu vực
     items:
-      telegram English:
-        name: Tiếng Anh
       telegram Español:
         name: Español
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: Diễn đàn
+    title: Diễn đàn khác
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r / EthereumClassic
       forum BitcoinTalk:
         name: BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: Let's Talk ETC!
   Twitter Accounts:
-    title: Tài khoản Twitter
+    title: Tài khoản Twitter theo khu vực
     items:
       twitter China:
         name: Trung Quốc
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: Español
       twitter France:

--- a/i18n/community/channels/index.vi.yaml
+++ b/i18n/community/channels/index.vi.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Discord Ethereum Classic
-        description: 'Máy chủ cộng đồng đầu tiên, hoạt động từ năm 2016, nơi đã diễn ra nhiều cuộc gọi của các nhà phát triển cốt lõi và các cuộc gọi cộng đồng trước đây.'
+        description: 'Máy chủ cộng đồng đầu tiên, hoạt động từ năm 2016, được kiểm duyệt nhẹ, nơi đã diễn ra nhiều cuộc gọi của các nhà phát triển cốt lõi và các cuộc gọi cộng đồng trước đây.'
       discordCommunity:
         name: Discord Cộng đồng Ethereum Classic
-        description: 'Máy chủ mới hơn, ra mắt vào tháng 11 năm 2025, được kiểm duyệt chặt chẽ hơn và có xác minh tự động, chống thư rác cùng các tích hợp thông báo. Xem [bài đăng thông báo](/blog/2025-11-05-discord-migration) để biết bối cảnh.'
+        description: 'Máy chủ mới hơn, ra mắt vào tháng 11 năm 2025, được kiểm duyệt chặt chẽ và có xác minh tự động, chống thư rác cùng các tích hợp thông báo. Xem [bài đăng thông báo](/blog/2025-11-05-discord-migration) để biết bối cảnh.'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: 'Nhóm xoay quanh [ETC Grants DAO](https://etcgrantsdao.io), tổ chức tài trợ cho các dự án xây dựng trên Ethereum Classic. Đây là một trong những nhóm trò chuyện ETC sôi nổi nhất, với nhiều người dùng tích cực bàn luận về hệ sinh thái mỗi ngày.'
       telegramEnglish:
         name: Ethereum Classic (tiếng Anh)
         description: Nhóm tiếng Anh lâu đời để trò chuyện chung về ETC.
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: 'Nhóm xoay quanh [ETC Grants DAO](https://etcgrantsdao.io), tổ chức tài trợ cho các dự án xây dựng trên Ethereum Classic.'
   twitter:
     description: |
-      Hai tài khoản cộng đồng chính được vận hành bằng [twitter-together](https://github.com/twitter-together/action): các tweet được đề xuất dưới dạng pull request vào kho lưu trữ của tài khoản, được xem xét công khai và tự động đăng khi hợp nhất. Cách đơn giản nhất để đề xuất là dùng [ứng dụng đóng góp ETC](https://etc.contributions.app), ứng dụng này sẽ gửi pull request thay bạn, dù bạn có tài khoản GitHub hay không. Ý tưởng cũng được lấy từ các tweet gắn thẻ `#ETCtweets` và được thảo luận trong luồng `#ETCtweets` trên Discord.
+      Hai tài khoản do cộng đồng vận hành sử dụng [twitter-together](https://github.com/twitter-together/action): các tweet được đề xuất dưới dạng pull request vào kho lưu trữ của tài khoản, được xem xét công khai và tự động đăng khi hợp nhất. Cách đơn giản nhất để đề xuất là dùng [ứng dụng đóng góp ETC](https://etc.contributions.app), ứng dụng này sẽ gửi pull request thay bạn, dù bạn có tài khoản GitHub hay không. Ý tưởng cũng được lấy từ các tweet gắn thẻ `#ETCtweets` và được thảo luận trong luồng `#ETCtweets` trên Discord.
     items:
       twitterEthClassic:
         description: 'Tài khoản có nhiều người theo dõi hơn trong hai tài khoản, với quy tắc biên tập giữ cho nội dung trang trọng, trung lập và không đăng meme. Tweet được đề xuất tại [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic).'

--- a/i18n/community/channels/index.zh-yue.yaml
+++ b/i18n/community/channels/index.zh-yue.yaml
@@ -1,17 +1,43 @@
 title: 社交渠道
 seo: Ethereum Classic 聊天室、Twitter 帳戶、討論組、論壇、播客、存儲庫和區域網站的集合。
 description: |
-  以下是活躍的 Ethereum Classic 討論頻道和群組的非詳盡列表。
+  Ethereum Classic 沒有中心化的組織，因此也沒有「官方」的社交媒體；這裡列出的每個渠道都由社群成員各自獨立營運。
 
-  目前 ETC 社區內的主要活動中心在 [Discord](https://ethereumclassic.org/discord)。
+  Discord、Telegram、Twitter 和 Reddit 這幾個部分涵蓋了本網站頁尾所連結的渠道。其餘部分是各地區和特定主題群組的不完全彙總；其中部分內容已有一段時間未經核對，因此可能有失效的連結。
 items:
-  Chat Rooms:
-    title: 聊天室
+  discord:
+    description: |
+      目前有兩個一般用途的 ETC Discord 伺服器，兩個都在活躍運作。以下按建立時間先後排列，並無優劣之分；你可以加入其中任何一個，或者兩個都加入。
     items:
-      chat Discord:
-        name: Discord（社區，全球）
-      chat Discord Coop:
-        name: 不和諧（ETC Coop）
+      discordClassic:
+        name: Ethereum Classic Discord
+        description: 最早的社群伺服器，自 2016 年起運作，過去許多核心開發者會議和社群會議都在這裡舉行。
+      discordCommunity:
+        name: Ethereum Classic 社群 Discord
+        description: '較新的伺服器，於 2025 年 11 月啟用，審核較為嚴格，並設有自動驗證、防垃圾訊息和公告整合功能。背景資料見[公告文章](/blog/2025-11-05-discord-migration)。'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: '圍繞 [ETC Grants DAO](https://etcgrantsdao.io) 的群組，該組織為在 Ethereum Classic 上開發的項目提供資助。這是最熱鬧的 ETC 聊天群之一，有許多活躍用戶每日討論生態系統的動態。'
+      telegramEnglish:
+        name: Ethereum Classic（英文）
+        description: 歷史悠久的英文群組，用來討論 ETC 的各類話題。
+  twitter:
+    description: |
+      兩個主要的社群帳戶透過 [twitter-together](https://github.com/twitter-together/action) 運作：推文以 pull request 的形式提交到帳戶對應的儲存庫，公開審核，合併後自動發佈。最簡單的提議方式是使用 [ETC 貢獻應用程式](https://etc.contributions.app)，無論你有沒有 GitHub 帳戶，它都會代你提交 pull request。帶有 `#ETCtweets` 標籤的推文也會被採納為素材，並在 Discord 的 `#ETCtweets` 討論串中討論。
+    items:
+      twitterEthClassic:
+        description: '兩個帳戶中追蹤者較多的一個，其編輯規範令它保持正式、中立，不發佈迷因內容。推文在 [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) 中提出。'
+      twitterEtcNetwork:
+        description: '風格較輕鬆的帳戶，除網絡與開發動態外，亦容許發佈迷因和較隨意的內容。推文在 [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network) 中提出。'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: Ethereum Classic 的 subreddit，適合較長篇的討論、提問，以及分享來自整個生態系統的新聞和連結。
+  Chat Rooms:
+    title: 其他聊天室
+    items:
       chat Facebook English:
         name: 臉書（英文）
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: 超級賬本貝蘇
   Telegram Groups:
-    title: 電報群
+    title: 各地區 Telegram 群組
     items:
-      telegram English:
-        name: 英語
       telegram Español:
         name: 西班牙語
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 中文
   Forums:
-    title: 論壇
+    title: 其他論壇
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/以太坊經典
       forum BitcoinTalk:
         name: 比特幣對話
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: 讓我們談談ETC！
   Twitter Accounts:
-    title: 推特賬號
+    title: 各地區 Twitter 帳戶
     items:
       twitter China:
         name: 中國
-      twitter English 1:
-        name: "@ETC_網絡"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: 西班牙語
       twitter France:

--- a/i18n/community/channels/index.zh-yue.yaml
+++ b/i18n/community/channels/index.zh-yue.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Ethereum Classic Discord
-        description: 最早的社群伺服器，自 2016 年起運作，過去許多核心開發者會議和社群會議都在這裡舉行。
+        description: 最早的社群伺服器，自 2016 年起運作，審核寬鬆，過去許多核心開發者會議和社群會議都在這裡舉行。
       discordCommunity:
         name: Ethereum Classic 社群 Discord
-        description: '較新的伺服器，於 2025 年 11 月啟用，審核較為嚴格，並設有自動驗證、防垃圾訊息和公告整合功能。背景資料見[公告文章](/blog/2025-11-05-discord-migration)。'
+        description: '較新的伺服器，於 2025 年 11 月啟用，審核嚴格，並設有自動驗證、防垃圾訊息和公告整合功能。背景資料見[公告文章](/blog/2025-11-05-discord-migration)。'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: '圍繞 [ETC Grants DAO](https://etcgrantsdao.io) 的群組，該組織為在 Ethereum Classic 上開發的項目提供資助。這是最熱鬧的 ETC 聊天群之一，有許多活躍用戶每日討論生態系統的動態。'
       telegramEnglish:
         name: Ethereum Classic（英文）
         description: 歷史悠久的英文群組，用來討論 ETC 的各類話題。
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: '圍繞 [ETC Grants DAO](https://etcgrantsdao.io) 的群組，該組織為在 Ethereum Classic 上開發的項目提供資助。'
   twitter:
     description: |
-      兩個主要的社群帳戶透過 [twitter-together](https://github.com/twitter-together/action) 運作：推文以 pull request 的形式提交到帳戶對應的儲存庫，公開審核，合併後自動發佈。最簡單的提議方式是使用 [ETC 貢獻應用程式](https://etc.contributions.app)，無論你有沒有 GitHub 帳戶，它都會代你提交 pull request。帶有 `#ETCtweets` 標籤的推文也會被採納為素材，並在 Discord 的 `#ETCtweets` 討論串中討論。
+      由社群營運的兩個帳戶使用 [twitter-together](https://github.com/twitter-together/action)：推文以 pull request 的形式提交到帳戶對應的儲存庫，公開審核，合併後自動發佈。最簡單的提議方式是使用 [ETC 貢獻應用程式](https://etc.contributions.app)，無論你有沒有 GitHub 帳戶，它都會代你提交 pull request。帶有 `#ETCtweets` 標籤的推文也會被採納為素材，並在 Discord 的 `#ETCtweets` 討論串中討論。
     items:
       twitterEthClassic:
         description: '兩個帳戶中追蹤者較多的一個，其編輯規範令它保持正式、中立，不發佈迷因內容。推文在 [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) 中提出。'

--- a/i18n/community/channels/index.zh.yaml
+++ b/i18n/community/channels/index.zh.yaml
@@ -1,17 +1,43 @@
 title: 社会渠道
 seo: 以太坊经典聊天室、Twitter账户、讨论组、论坛、播客、存储库和区域网站的集合。
 description: |
-  以下是一份非详尽的活跃的Ethereum Classic讨论频道和小组的清单。
+  Ethereum Classic 没有中心化的组织，因此也没有“官方”的社交媒体；这里列出的每个渠道都由社区成员各自独立运营。
 
-  目前ETC社区内的主要活动中心是在 [Discord](https://ethereumclassic.org/discord)。
+  Discord、Telegram、Twitter 和 Reddit 这几个部分涵盖了本网站页脚中链接的渠道。其余部分是各地区和特定主题群组的不完全汇总；其中一些内容已经有一段时间没有核对，因此可能存在失效的链接。
 items:
-  Chat Rooms:
-    title: 聊天室
+  discord:
+    description: |
+      目前有两个面向一般用途的 ETC Discord 服务器，都在活跃使用中。以下按创建时间先后排列，并无优劣之分；你可以加入其中任意一个，或者两个都加入。
     items:
-      chat Discord:
-        name: Discord (社区, 全球)
-      chat Discord Coop:
-        name: Discord (ETC Coop)
+      discordClassic:
+        name: Ethereum Classic Discord
+        description: 最早的社区服务器，自 2016 年起运行，过去许多核心开发者会议和社区会议都在这里举行。
+      discordCommunity:
+        name: Ethereum Classic 社区 Discord
+        description: '较新的服务器，于 2025 年 11 月上线，审核更为严格，并配有自动验证、反垃圾信息和公告集成功能。背景信息见[公告文章](/blog/2025-11-05-discord-migration)。'
+  telegram:
+    items:
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: '围绕 [ETC Grants DAO](https://etcgrantsdao.io) 的群组，该组织为在 Ethereum Classic 上开发的项目提供资助。这是最热闹的 ETC 聊天群之一，有许多活跃用户每天讨论生态系统的动态。'
+      telegramEnglish:
+        name: Ethereum Classic（英文）
+        description: 历史悠久的英文群组，用于讨论 ETC 的各类话题。
+  twitter:
+    description: |
+      两个主要的社区账号通过 [twitter-together](https://github.com/twitter-together/action) 运作：推文以 pull request 的形式提交到账号对应的仓库，公开审核，合并后自动发布。最简单的提议方式是使用 [ETC 贡献应用](https://etc.contributions.app)，无论你是否拥有 GitHub 账号，它都会替你提交 pull request。带有 `#ETCtweets` 标签的推文也会被采纳为素材，并在 Discord 的 `#ETCtweets` 讨论串中讨论。
+    items:
+      twitterEthClassic:
+        description: '两个账号中关注者较多的一个，其编辑规范使其保持正式、中立，不发表迷因内容。推文在 [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) 中提出。'
+      twitterEtcNetwork:
+        description: '风格较轻松的账号，除网络与开发动态外，也允许发布迷因和较随意的内容。推文在 [tweets-etc_network](https://github.com/ethereumclassic/tweets-etc_network) 中提出。'
+  reddit:
+    items:
+      redditEthereumClassic:
+        description: Ethereum Classic 的 subreddit，适合较长篇的讨论、提问，以及分享来自整个生态系统的新闻和链接。
+  Chat Rooms:
+    title: 其他聊天室
+    items:
       chat Facebook English:
         name: 脸书(英文)
       chat Facebook Vietnam:
@@ -32,10 +58,8 @@ items:
       Hyperledger Besu dev:
         name: Hyperledger Besu
   Telegram Groups:
-    title: 电报组
+    title: 各地区 Telegram 群组
     items:
-      telegram English:
-        name: 英语
       telegram Español:
         name: 班牙语
       telegram Italia:
@@ -47,10 +71,8 @@ items:
       telegram China:
         name: 淘宝网
   Forums:
-    title: 论坛
+    title: 其他论坛
     items:
-      forum RedditEthereumClassic:
-        name: Reddit r/EthereumClassic
       forum BitcoinTalk:
         name: 比特币话题(BitcoinTalk
       forum Archived BitcoinTalk:
@@ -75,14 +97,10 @@ items:
       media Let's Talk ETC!:
         name: 让我们谈谈ETC!
   Twitter Accounts:
-    title: 推特账户
+    title: 各地区 Twitter 账号
     items:
       twitter China:
         name: 中国
-      twitter English 1:
-        name: "@ETC_Network"
-      twitter English 2:
-        name: "@eth_classic"
       twitter Español:
         name: 班牙语
       twitter France:

--- a/i18n/community/channels/index.zh.yaml
+++ b/i18n/community/channels/index.zh.yaml
@@ -11,21 +11,21 @@ items:
     items:
       discordClassic:
         name: Ethereum Classic Discord
-        description: 最早的社区服务器，自 2016 年起运行，过去许多核心开发者会议和社区会议都在这里举行。
+        description: 最早的社区服务器，自 2016 年起运行，审核宽松，过去许多核心开发者会议和社区会议都在这里举行。
       discordCommunity:
         name: Ethereum Classic 社区 Discord
-        description: '较新的服务器，于 2025 年 11 月上线，审核更为严格，并配有自动验证、反垃圾信息和公告集成功能。背景信息见[公告文章](/blog/2025-11-05-discord-migration)。'
+        description: '较新的服务器，于 2025 年 11 月上线，审核严格，并配有自动验证、反垃圾信息和公告集成功能。背景信息见[公告文章](/blog/2025-11-05-discord-migration)。'
   telegram:
     items:
-      telegramGrantsDao:
-        name: ETC Grants DAO
-        description: '围绕 [ETC Grants DAO](https://etcgrantsdao.io) 的群组，该组织为在 Ethereum Classic 上开发的项目提供资助。这是最热闹的 ETC 聊天群之一，有许多活跃用户每天讨论生态系统的动态。'
       telegramEnglish:
         name: Ethereum Classic（英文）
         description: 历史悠久的英文群组，用于讨论 ETC 的各类话题。
+      telegramGrantsDao:
+        name: ETC Grants DAO
+        description: '围绕 [ETC Grants DAO](https://etcgrantsdao.io) 的群组，该组织为在 Ethereum Classic 上开发的项目提供资助。'
   twitter:
     description: |
-      两个主要的社区账号通过 [twitter-together](https://github.com/twitter-together/action) 运作：推文以 pull request 的形式提交到账号对应的仓库，公开审核，合并后自动发布。最简单的提议方式是使用 [ETC 贡献应用](https://etc.contributions.app)，无论你是否拥有 GitHub 账号，它都会替你提交 pull request。带有 `#ETCtweets` 标签的推文也会被采纳为素材，并在 Discord 的 `#ETCtweets` 讨论串中讨论。
+      由社区运营的两个账号使用 [twitter-together](https://github.com/twitter-together/action)：推文以 pull request 的形式提交到账号对应的仓库，公开审核，合并后自动发布。最简单的提议方式是使用 [ETC 贡献应用](https://etc.contributions.app)，无论你是否拥有 GitHub 账号，它都会替你提交 pull request。带有 `#ETCtweets` 标签的推文也会被采纳为素材，并在 Discord 的 `#ETCtweets` 讨论串中讨论。
     items:
       twitterEthClassic:
         description: '两个账号中关注者较多的一个，其编辑规范使其保持正式、中立，不发表迷因内容。推文在 [tweets-eth_classic](https://github.com/ethereumclassic/tweets-eth_classic) 中提出。'

--- a/netlify.toml
+++ b/netlify.toml
@@ -34,10 +34,13 @@
 [[redirects]]
   from = "/sitemap.xml"
   to = "/sitemap-index.xml"
-# fallback for cloudflare handled redirect
 [[redirects]]
   from = "/discord"
-  to = "https://discord.com/invite/Tq57jxSwsa"
+  to = "/community/channels"
+  status = 302
+[[redirects]]
+  from = "/socials"
+  to = "/community/channels"
   status = 302
 
 # 2019 Redirects

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -30,7 +30,11 @@ export default function Link({
   const nowrap = isString(children) && children.length < 20;
   const linkProps = {
     ...(useAComp
-      ? { href: url, target: isExternal ? "_blank" : null }
+      ? {
+          href: url,
+          target: isExternal ? "_blank" : null,
+          rel: isExternal ? "noopener noreferrer" : null,
+        }
       : { to: url, notLocalized }),
     ...(scrollTo && { state: { scrollTo } }),
   };

--- a/src/components/socialIcons.js
+++ b/src/components/socialIcons.js
@@ -3,6 +3,7 @@ import tw from "twin.macro";
 
 import { useGlobals } from "../../plugins/translations-plugin/src/components/localizationProvider";
 import Icon from "./icon";
+import Link from "./link";
 import Tooltip from "./tooltip";
 
 export default function SocialIcons() {
@@ -15,10 +16,8 @@ export default function SocialIcons() {
       <div tw="flex space-x-4">
         {socialItems.map(({ key, name, icon, link, hilight }) => (
           <div className="group" tw="relative" key={key}>
-            <a
-              target="_blank"
-              rel="noreferrer"
-              href={link}
+            <Link
+              to={link}
               css={[
                 hilight
                   ? tw`text-secondary-neutral hover:text-secondary-dark`
@@ -35,7 +34,7 @@ export default function SocialIcons() {
                 )}
                 <Icon icon={icon} tw="h-6" />
               </div>
-            </a>
+            </Link>
             <Tooltip>{name}</Tooltip>
           </div>
         ))}


### PR DESCRIPTION
This PR makes the website stop picking a winner among the community's social channels. Ethereum Classic has no central organisation and no official accounts, but the footer implied otherwise: it linked straight out to a fixed set of accounts, and singled out one of the two Discord servers as the highlighted one, quietly making the footer the arbiter of which server is "the" ETC Discord, a question the community hasn't settled. A list that documents the channels, rather than a link that chooses one, is a better fit for how the project actually works.

So every footer social icon now points at `/community/channels`, as do `/discord` and a new `/socials` shorthand, and that page is expanded to cover what the footer used to link directly, both general purpose Discord servers described neutrally and listed in the order they were created, added the ETC Grants DAO and English Telegram groups, the two twitter-together accounts with a note on how anyone can propose a tweet via the ETC Contributions app, and Reddit. Entries absorbed by those sections are dropped from the button lists below, which now read as the regional and other directories.

The 20 translations and the Crowdin editor placeholder file are updated to match, so the localised pages stay coherent This PR makes the website stop picking a winner among the community's social channels. Ethereum Classic has no central organisation and no official accounts, but the footer implied otherwise: it linked straight out to a fixed set of accounts, and singled out one of the two Discord servers as the highlighted one — quietly making the footer the arbiter of which server is "the" ETC Discord, a question the community hasn't settled. A list that documents the channels, rather than a link that chooses one, is a better fit for how the project actually works.

So every footer social icon now points at /community/channels, as do /discord and a new /socials shorthand, and that page is expanded to cover what the footer used to link directly: both general purpose Discord servers described neutrally and listed in the order they were created, the ETC Grants DAO and English Telegram groups, the two twitter-together accounts with a note on how anyone can propose a tweet via the ETC Contributions app, and Reddit. Entries absorbed by those sections are dropped from the button lists below, which now read as the regional and other directories.

The 20 translations and the Crowdin editor placeholder file are updated to match, so the localised pages stay coherent.

This is an alternative to #1683